### PR TITLE
[Outlook] (signature sample) Update requirement set and supported platform

### DIFF
--- a/Samples/outlook-set-signature/README.md
+++ b/Samples/outlook-set-signature/README.md
@@ -16,7 +16,7 @@ description: "Use Outlook event-based activation to set the signature."
 
 # Use Outlook event-based activation to set the signature
 
-**Applies to:** Outlook on Windows | Outlook on the web
+**Applies to:** Outlook on Windows | Outlook on the web | Outlook on Mac (new UI preview)
 
 ## Summary
 
@@ -33,7 +33,8 @@ For documentation related to this sample, see [Configure your Outlook add-in for
 
 - Outlook
   - Windows
-  - web browser
+  - Web browser
+  - new Mac UI (preview)
 
 ## Prerequisites
 
@@ -61,16 +62,16 @@ In this scenario, the add-in helps the user manage their email signature, even w
 
 ## Run the sample
 
-You can run this sample in Outlook on Windows or in a browser. The add-in web files are served from this repo on GitHub.
+You can run this sample in Outlook on Windows, Outlook on Mac (new UI in preview), or in a browser. The add-in web files are served from this repo on GitHub.
 
 1. Download the **manifest.xml** file from this sample to a folder on your computer.
-1. Sideload the add-in manifest in Outlook on the web or on Windows by following the manual instructions in the article [Sideload Outlook add-ins for testing](https://docs.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing).
+1. Sideload the add-in manifest in Outlook on the web, on Windows, or on Mac by following the manual instructions in the article [Sideload Outlook add-ins for testing](https://docs.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing).
 
 ### Try it out
 
 Once the add-in is loaded use the following steps to try out the functionality.
 
-1. Open Outlook on Windows or in a browser.
+1. Open Outlook on Windows, on Mac, or in a browser.
 1. Create a new message or appointment.
 
     > You should see a notification at the top of the message that reads: **Please set your signature with the PnP sample add-in.**
@@ -111,14 +112,14 @@ If you prefer to host the web server for the sample on your computer, follow the
     office-addin-https-reverse-proxy --url http://localhost:3000 
     ```
 
-1. Sideload `manifest-localhost.xml` in Outlook on the web or on Windows by following the manual instructions in the article [Sideload Outlook add-ins for testing](https://docs.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing).
+1. Sideload `manifest-localhost.xml` in Outlook on the web, on Windows, or on Mac by following the manual instructions in the article [Sideload Outlook add-ins for testing](https://docs.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing).
 1. [Try out the sample!](#try-it-out)
 
 ## Key parts of this sample
 
 ### Configure event-based activation in the manifest
 
-The manifest configures a runtime that is loaded specifically to handle event-based activation. The following `<Runtime>` element specifies an HTML page resource id that loads the runtime on Outlook on the web. The `<Override>` element specifies the JavaScript file instead, to load the runtime for Outlook on Windows. Outlook on Windows doesn't use the HTML page to load the runtime.
+The manifest configures a runtime that is loaded specifically to handle event-based activation. The following `<Runtime>` element specifies an HTML page resource ID that loads the runtime on Outlook on the web and Outlook on Mac. The `<Override>` element specifies the JavaScript file instead, to load the runtime for Outlook on Windows. Outlook on Windows doesn't use the HTML page to load the runtime.
 
 ```xml
 <Runtime resid="Autorun">
@@ -139,11 +140,11 @@ The add-in handles two events that are mapped to the `checkSignature()` function
 
 ### Handling the events and using the setSignatureAsync API
 
-When the user creates a new message or appointment, Outlook will load the files specified in the manifest to handle the `OnNewMessageCompose` and `OnNewAppointmentOrganizer` events. Outlook on the web will load the `autorunweb.html` page, which then also loads `autorunweb.js` and `autorunshared.js`.
+When the user creates a new message or appointment, Outlook will load the files specified in the manifest to handle the `OnNewMessageCompose` and `OnNewAppointmentOrganizer` events. Outlook on the web and Outlook on Mac will load the `autorunweb.html` page, which then also loads `autorunweb.js` and `autorunshared.js`.
 
 The `autorunweb.js` file contains a version of the `insert_auto_signature` function used specifically when running on Outlook on the web. The [setSignatureAsync() API cannot be used in Outlook on the web for appointments](https://docs.microsoft.com/javascript/api/outlook/office.body?view=outlook-js-preview#setSignatureAsync_data__options__callback_). Therefore, `insert_auto_signature` inserts the signature into a new appointment by directly writing to the body text of the appointment.
 
-The `autorunshared.js` file contains the `checkSignature` function that handles the events from Outlook. It also contains additional code that is shared and loaded when the add-in is used in Outlook on the web and Outlook on Windows. On Outlook on Windows, this file is loaded directly and `autorunweb.html` and `autorunweb.js` are not loaded.
+The `autorunshared.js` file contains the `checkSignature` function that handles the events from Outlook. It also contains additional code that is shared and loaded when the add-in is used in Outlook on the web, Outlook on Windows, and Outlook on Mac. On Outlook on Windows, this file is loaded directly and `autorunweb.html` and `autorunweb.js` are not loaded.
 
 The `autorunshared.js` file contains a version of the `insert_auto_signature` function that uses the `setSignatureAsync()` API to set the signature for both messages and appointments.
 

--- a/Samples/outlook-set-signature/README.md
+++ b/Samples/outlook-set-signature/README.md
@@ -62,7 +62,7 @@ In this scenario, the add-in helps the user manage their email signature, even w
 
 ## Run the sample
 
-You can run this sample in Outlook on Windows, Outlook on Mac (new UI in preview), or in a browser. The add-in web files are served from this repo on GitHub.
+You can run this sample in Outlook on Windows, on Mac (new UI in preview), or in a browser. The add-in web files are served from this repo on GitHub.
 
 1. Download the **manifest.xml** file from this sample to a folder on your computer.
 1. Sideload the add-in manifest in Outlook on the web, on Windows, or on Mac by following the manual instructions in the article [Sideload Outlook add-ins for testing](https://docs.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing).
@@ -119,7 +119,7 @@ If you prefer to host the web server for the sample on your computer, follow the
 
 ### Configure event-based activation in the manifest
 
-The manifest configures a runtime that is loaded specifically to handle event-based activation. The following `<Runtime>` element specifies an HTML page resource ID that loads the runtime on Outlook on the web and Outlook on Mac. The `<Override>` element specifies the JavaScript file instead, to load the runtime for Outlook on Windows. Outlook on Windows doesn't use the HTML page to load the runtime.
+The manifest configures a runtime that is loaded specifically to handle event-based activation. The following `<Runtime>` element specifies an HTML page resource ID that loads the runtime on Outlook on the web and on Mac. The `<Override>` element specifies the JavaScript file instead, to load the runtime for Outlook on Windows. Outlook on Windows doesn't use the HTML page to load the runtime.
 
 ```xml
 <Runtime resid="Autorun">
@@ -140,11 +140,11 @@ The add-in handles two events that are mapped to the `checkSignature()` function
 
 ### Handling the events and using the setSignatureAsync API
 
-When the user creates a new message or appointment, Outlook will load the files specified in the manifest to handle the `OnNewMessageCompose` and `OnNewAppointmentOrganizer` events. Outlook on the web and Outlook on Mac will load the `autorunweb.html` page, which then also loads `autorunweb.js` and `autorunshared.js`.
+When the user creates a new message or appointment, Outlook will load the files specified in the manifest to handle the `OnNewMessageCompose` and `OnNewAppointmentOrganizer` events. Outlook on the web and on Mac will load the `autorunweb.html` page, which then also loads `autorunweb.js` and `autorunshared.js`.
 
 The `autorunweb.js` file contains a version of the `insert_auto_signature` function used specifically when running on Outlook on the web. The [setSignatureAsync() API cannot be used in Outlook on the web for appointments](https://docs.microsoft.com/javascript/api/outlook/office.body?view=outlook-js-preview#setSignatureAsync_data__options__callback_). Therefore, `insert_auto_signature` inserts the signature into a new appointment by directly writing to the body text of the appointment.
 
-The `autorunshared.js` file contains the `checkSignature` function that handles the events from Outlook. It also contains additional code that is shared and loaded when the add-in is used in Outlook on the web, Outlook on Windows, and Outlook on Mac. On Outlook on Windows, this file is loaded directly and `autorunweb.html` and `autorunweb.js` are not loaded.
+The `autorunshared.js` file contains the `checkSignature` function that handles the events from Outlook. It also contains additional code that is shared and loaded when the add-in is used in Outlook on the web, on Windows, and on Mac. In Outlook on Windows, this file is loaded directly and `autorunweb.html` and `autorunweb.js` are not loaded.
 
 The `autorunshared.js` file contains a version of the `insert_auto_signature` function that uses the `setSignatureAsync()` API to set the signature for both messages and appointments.
 

--- a/Samples/outlook-set-signature/README.md
+++ b/Samples/outlook-set-signature/README.md
@@ -148,7 +148,7 @@ The `autorunshared.js` file contains the `checkSignature` function that handles 
 
 The `autorunshared.js` file contains a version of the `insert_auto_signature` function that uses the `setSignatureAsync()` API to set the signature for both messages and appointments.
 
-Note that you can use a similar pattern when handling events. If you need code that only applies to Outlook on the web, you can load it in a separate file like `autorunweb.js`. And for code that applies to both Outlook on the web and Outlook on Windows, you can load it in a shared file like `autorunshared.js`.
+Note that you can use a similar pattern when handling events. If you need code that only applies to Outlook on the web, you can load it in a separate file like `autorunweb.js`. And for code that applies to Outlook on the web, on Windows, and on Mac, you can load it in a shared file like `autorunshared.js`.
 
 ### Embedding images with the signature
 

--- a/Samples/outlook-set-signature/manifest.xml
+++ b/Samples/outlook-set-signature/manifest.xml
@@ -40,7 +40,7 @@
       <Description resid="residAppDesc" />
 
       <Requirements>
-        <bt:Sets DefaultMinVersion="1.3">
+        <bt:Sets DefaultMinVersion="1.10">
           <bt:Set Name="Mailbox" />
         </bt:Sets>
       </Requirements>

--- a/Samples/outlook-set-signature/src/runtime/Js/autorunshared.js
+++ b/Samples/outlook-set-signature/src/runtime/Js/autorunshared.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// Contains code for event-based activation on both Outlook on web and Outlook on Windows.
+// Contains code for event-based activation on Outlook on web, on Windows, and on Mac (new UI preview).
 
 /**
  * Checks if signature exists.
@@ -45,8 +45,8 @@ function checkSignature(eventObj) {
 }
 
 /**
- * For Outlook on Windows only. Insert signature into appointment or message.
- * Outlook on Windows can use setSignatureAsync method on appointments and messages.
+ * For Outlook on Windows and on Mac only. Insert signature into appointment or message.
+ * Outlook on Windows and on Mac can use setSignatureAsync method on appointments and messages.
  * @param {*} compose_type The compose type (reply, forward, newMail)
  * @param {*} user_info Information details about the user
  * @param {*} eventObj Office event object

--- a/Samples/outlook-set-signature/src/runtime/Js/autorunweb.js
+++ b/Samples/outlook-set-signature/src/runtime/Js/autorunweb.js
@@ -24,7 +24,7 @@ function insert_auto_signature(compose_type, user_info, eventObj) {
 }
 
 /**
- * For Outlook on the seb, set signature for current appointment
+ * For Outlook on the web, set signature for current appointment
 * @param {*} signatureDetails object containing:
  *  "signature": The signature HTML of the template,
     "logoBase64": The base64 encoded logo image,


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?             | yes |
| New feature?    | no |
| New sample?    | no |
| Related issues? | fixes #293 |

## What's in this Pull Request?

Updated the outlook-set-signature sample to–
- correct the minimum requirement set specified in the manifest to 1.10; and
- add support for Outlook on Mac new UI (preview).

## Guidance

Updated the outlook-set-signature sample to–
- correct the minimum requirement set specified in the manifest to 1.10; and
- add support for Outlook on Mac new UI (preview).