### PR TITLE
[VSTO shared migration] remove certificates from CS projects

### DIFF
--- a/Samples/VSTO-shared-code-migration/completed/Cell-Analyzer/Cell-Analyzer.csproj
+++ b/Samples/VSTO-shared-code-migration/completed/Cell-Analyzer/Cell-Analyzer.csproj
@@ -213,10 +213,10 @@
     <SignManifests>true</SignManifests>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestKeyFile>Cell-Analyzer_2_TemporaryKey.pfx</ManifestKeyFile>
+    <ManifestKeyFile>Cell-Analyzer_TemporaryKey.pfx</ManifestKeyFile>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestCertificateThumbprint>605D04F3D52724A3C20E2B2BDC153B6B1ABBB6A4</ManifestCertificateThumbprint>
+    <ManifestCertificateThumbprint>F987346A1E2C50FA8169588CC5DAFFE5057C985C</ManifestCertificateThumbprint>
   </PropertyGroup>
   <!-- Include the build rules for a C# project. -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Samples/VSTO-shared-code-migration/start/Cell-Analyzer/Cell-Analyzer.csproj
+++ b/Samples/VSTO-shared-code-migration/start/Cell-Analyzer/Cell-Analyzer.csproj
@@ -206,10 +206,10 @@
     <SignManifests>true</SignManifests>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestKeyFile>Cell-Analyzer_1_TemporaryKey.pfx</ManifestKeyFile>
+    <ManifestKeyFile>Cell-Analyzer_TemporaryKey.pfx</ManifestKeyFile>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestCertificateThumbprint>C1D12EA6C996B98B21E522F6358A69B79D4F0AF0</ManifestCertificateThumbprint>
+    <ManifestCertificateThumbprint>2AD0C77F92D5251087E27CBF0513B23B2E0D1201</ManifestCertificateThumbprint>
   </PropertyGroup>
   <!-- Include the build rules for a C# project. -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no                                |
| New sample?     | no                                |
| Related issues? | fixes #3485 in office-js-docs-pr |

## What's in this Pull Request?

This removes the manifest certificate references in the CS project files for Visual Studio. They cause an error since the certificates are not provided in the repo. They are not needed.
