### PR TITLE
Add security note to SSO samples

### DIFF
--- a/Samples/auth/Office-Add-in-ASPNET-SSO/README.md
+++ b/Samples/auth/Office-Add-in-ASPNET-SSO/README.md
@@ -23,6 +23,8 @@ extensions:
 
 This sample implements an Office Add-in that uses the `getAccessToken` API in Office.js to give the add-in access to Microsoft Graph data. This sample is built on ASP.NET and Microsoft Authentication Library (MSAL) .NET.
 
+> Note: This sample has a security risk because it returns an access token from the middle-tier server to the client code. This pattern should not be used as tokens issued by the Microsoft identity platform to the middle-tier must stay in the middle-tier. We're working to update this sample with the correct pattern as soon as possible. For more information, see [Middle-tier access token request](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow#middle-tier-access-token-request).
+
 There are two versions of the sample in this repo, one of which has its own README file:
 
 - **Before** folder. The starting point for the SSO walkthrough at [Create an ASP.NET Office Add-in that uses single sign-on](https://docs.microsoft.com/office/dev/add-ins/develop/create-sso-office-add-ins-aspnet). Please follow the instructions in the article.

--- a/Samples/auth/Office-Add-in-NodeJS-SSO/README.md
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/README.md
@@ -22,6 +22,8 @@ extensions:
 
 The `getAccessToken` API in Office.js enables users who are signed into Office to get access to an AAD-protected add-in and to Microsoft Graph without needing to sign-in again. 
 
+> Note: This sample has a security risk because it returns an access token from the middle-tier server to the client code. This pattern should not be used as tokens issued by the Microsoft identity platform to the middle-tier must stay in the middle-tier. We're working to update this sample with the correct pattern as soon as possible. For more information, see [Middle-tier access token request](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow#middle-tier-access-token-request).
+
 There are three versions of the sample in this repo, one of which has its own README file:
 
 - In the **Begin** folder is the starting point for the SSO walkthrough at [Create a Node.js Office Add-in that uses single sign-on](https://docs.microsoft.com/office/dev/add-ins/develop/create-sso-office-add-ins-nodejs). Please follow the instructions in the article.

--- a/Samples/auth/Outlook-Add-in-SSO/README.md
+++ b/Samples/auth/Outlook-Add-in-SSO/README.md
@@ -18,6 +18,8 @@ description: "An Outlook add-in sample that accesses Microsoft Graph using singl
 
 **Applies to:** Outlook on Windows | Outlook on Mac | Outlook on the web
 
+> Note: This sample has a security risk because it returns an access token from the middle-tier server to the client code. This pattern should not be used as tokens issued by the Microsoft identity platform to the middle-tier must stay in the middle-tier. We're working to update this sample with the correct pattern as soon as possible. For more information, see [Middle-tier access token request](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow#middle-tier-access-token-request).
+
 ## Summary
 
 The sample implements an Outlook add-in that uses Office's SSO feature to give the add-in access to Microsoft Graph data. Specifically, it enables the user to save all attachments to their OneDrive. It also shows how to add custom buttons to the Outlook ribbon. The sample illustrates the following concepts:


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                            |
| New feature?    | no                            |
| New sample?     | no                            |
| Related issues? | NA  |

## What's in this Pull Request?

Add security note that the SSO samples are using a pattern of returning the OBO obtained Graph token from middle-tier to client. This will be fixed soon, but for now need to warn developers about this pattern. The risks around this pattern are documented at https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow#middle-tier-access-token-request