### PR TITLE
[SSO Node JS](Add caching support for fallback auth)

### DIFF
--- a/Samples/auth/Office-Add-in-NodeJS-SSO/Begin/public/javascripts/fallback-msal/authRedirect.js
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/Begin/public/javascripts/fallback-msal/authRedirect.js
@@ -24,7 +24,7 @@ function handleResponse(response) {
 
   if (response !== null) {
     Office.context.ui.messageParent(
-      JSON.stringify({ status: "success", result: response.accessToken }),
+      JSON.stringify({ status: "success", result: response.accessToken, accountId: response.account.homeAccountId }),
       { targetOrigin: window.location.origin }
     );
   } else {

--- a/Samples/auth/Office-Add-in-NodeJS-SSO/Begin/public/javascripts/fallback-msal/fallbackAuthTaskpane.js
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/Begin/public/javascripts/fallback-msal/fallbackAuthTaskpane.js
@@ -15,8 +15,8 @@ async function dialogFallback(clientRequest) {
   if (homeAccountId !== null) {
     const result = await myMSALObj.acquireTokenSilent(loginRequest);
     if (result !== null && result.accessToken !== null) {
-      clientRequest.accessToken = result.accessToken;
-      clientRequest.callbackFunction(storedClientRequest);
+      clientRequest.accessToken = result.accessToken;    
+      clientRequest.callbackFunction(clientRequest);
     }
   } else {
     // Pop up dialog to sign in user.

--- a/Samples/auth/Office-Add-in-NodeJS-SSO/Begin/public/javascripts/fallback-msal/fallbackAuthTaskpane.js
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/Begin/public/javascripts/fallback-msal/fallbackAuthTaskpane.js
@@ -3,46 +3,77 @@
 
 // This file shows how to open a dialog and process any results sent back to the task pane.
 
-var loginDialog;
+let loginDialog = null;
+let homeAccountId = null;
 let storedCallbackFunction = null;
 let storedClientRequest = null;
 
-function dialogFallback(clientRequest) {
+const myMSALObj = new msal.PublicClientApplication(msalConfig);
+
+async function dialogFallback(clientRequest) {
+  // Attempt to acquire token silently if user is already signed in.
+  if (homeAccountId !== null) {
+    const result = await myMSALObj.acquireTokenSilent(loginRequest);
+    if (result !== null && result.accessToken !== null) {
+      clientRequest.accessToken = result.accessToken;
+      clientRequest.callbackFunction(storedClientRequest);
+    }
+  } else {
+    // Pop up dialog to sign in user.
     storedClientRequest = clientRequest;
-    var url = "/dialog.html"; 
-	showLoginPopup(url);
+    const url = "/dialog.html";
+    showLoginPopup(url);
+  }
 }
 
 // This handler responds to the success or failure message that the pop-up dialog receives from the identity provider
 // and access token provider.
 function processMessage(arg) {
+  console.log("Message received in processMessage");
+  let messageFromDialog = JSON.parse(arg.message);
 
-    console.log("Message received in processMessage");
-    let messageFromDialog = JSON.parse(arg.message);
+  if (messageFromDialog.status === "success") {
+    // We now have a valid access token.
+    loginDialog.close();
 
-        if (messageFromDialog.status === 'success') { 
-            // We now have a valid access token.
-            loginDialog.close();
-            storedClientRequest.accessToken = messageFromDialog.result;
-            storedClientRequest.callbackFunction(storedClientRequest);
-            //makeGraphApiCall(messageFromDialog.result);
-        }
-        else {
-            // Something went wrong with authentication or the authorization of the web application.
-            loginDialog.close();
-            showMessage(JSON.stringify(error.toString()));
-        }
+    homeAccountId = messageFromDialog.accountId; // Track the account id for future silent token requests.
+
+    // Configure MSAL to use the signed-in account as the active account for future requests.
+    const homeAccount = myMSALObj.getAccountByHomeId(
+      messageFromDialog.accountId
+    );
+    myMSALObj.setActiveAccount(homeAccount);
+
+    // Add access token to the client request and run the callback function.
+    storedClientRequest.accessToken = messageFromDialog.result;
+    storedClientRequest.callbackFunction(storedClientRequest);
+  } else {
+    // Something went wrong with authentication or the authorization of the web application.
+    loginDialog.close();
+    showMessage(JSON.stringify(error.toString()));
+  }
 }
 
 // Use the Office dialog API to open a pop-up and display the sign-in page for the identity provider.
 function showLoginPopup(url) {
-	var fullUrl = location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '') + url;
+  var fullUrl =
+    location.protocol +
+    "//" +
+    location.hostname +
+    (location.port ? ":" + location.port : "") +
+    url;
 
-	// height and width are percentages of the size of the parent Office application, e.g., PowerPoint, Excel, Word, etc.
-	Office.context.ui.displayDialogAsync(fullUrl,
-		{ height: 60, width: 30 }, function (result) {
-			console.log("Dialog has initialized. Wiring up events");
-			loginDialog = result.value;
-			loginDialog.addEventHandler(Office.EventType.DialogMessageReceived, processMessage);
-		});
+  // height and width are percentages of the size of the parent Office application, e.g., PowerPoint, Excel, Word, etc.
+  Office.context.ui.displayDialogAsync(
+    fullUrl,
+    { height: 60, width: 30 },
+    function (result) {
+      console.log("Dialog has initialized. Wiring up events");
+      loginDialog = result.value;
+      loginDialog.addEventHandler(
+        Office.EventType.DialogMessageReceived,
+        processMessage
+      );
+    }
+  );
 }

--- a/Samples/auth/Office-Add-in-NodeJS-SSO/Begin/public/javascripts/ssoAuthES6.js
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/Begin/public/javascripts/ssoAuthES6.js
@@ -32,7 +32,7 @@ Office.onReady(function (info) {
  *
  * @param {*} callbackFunction The function to pass the client request to when ready.
  */
- async function createRequest(url, restApiCallback, callbackFunction) {
+ async function createRequest(verb, url, restApiCallback, callbackFunction) {
     // TODO 1: Initialize the client request.
 
     // TODO 2: Get the access token.

--- a/Samples/auth/Office-Add-in-NodeJS-SSO/Begin/public/javascripts/ssoAuthES6.js
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/Begin/public/javascripts/ssoAuthES6.js
@@ -63,18 +63,6 @@ Office.onReady(function (info) {
   //         Check for error and display success or error message.
 }
 
-/**
- * Returns the access token for using SSO auth. Throws an error if SSO fails.
- * @param {*} authOptions The configuration options for SSO.
- * @returns An access token to the middle-tier server for the signed in user.
- */
- async function getAccessTokenFromSSO(authOptions) {
-  if (authOptions === undefined) throw Error("authOptions parameter missing.");
-    
-  // TODO 5: Get access token, and handle errors.
-
-  }
-
   /**
  * Handles any error returned from getAccessToken. The numbered errors are typically user actions
  * that don't require fallback auth. The text shown for each error indicates next steps
@@ -86,10 +74,10 @@ Office.onReady(function (info) {
  */
    function handleSSOErrors(err) {
 
-    // TODO 6: Handle errors where the add-in should NOT invoke 
+    // TODO 5: Handle errors where the add-in should NOT invoke 
     //         the alternative system of authorization.
 
-    // TODO 7: Handle errors where the add-in should invoke 
+    // TODO 6: Handle errors where the add-in should invoke 
     //         the alternative system of authorization.
 
    }
@@ -102,31 +90,13 @@ Office.onReady(function (info) {
  */
    async function callWebServer(clientRequest) {
     
-    // TODO 8: Call REST API and check for errors.
-    //         Get refreshed SSO token if current one expired.
+    // TODO 7: Call REST API with error handler.
+
+    // TODO 8: Check for expired SSO token and refresh if needed.
+
+    // TODO 9: Check for Microsoft Graph and other errors.
 
   }
-
-
-/**
- * Makes the AJAX call to the REST API in the middle-tier server.
- * Note that any errors are thrown to the caller to handle.
- * @param {} clientRequest Contains information for calling an API on the middle-tier server.
- */
- async function ajaxCallToRESTApi(clientRequest) {
-  // TODO 9: Make AJAX call to REST API on middle-tier server.
-}
-
-
-/**
- * Handles any error returned from the middle-tier server.
- * @param {*} err The error to process.
- * @returns {boolean} true if the caller should try the REST API again; otherwise false.
- */
- function handleWebServerErrors(err, clientRequest) {
- // TODO 10: Examine error and show message or
- //          Indicate to caller to get new SSO token.
-}
 
 /**
  * Switches the client request to use MSAL auth (fallback) instead of SSO. 
@@ -135,5 +105,5 @@ Office.onReady(function (info) {
  * @param {*} clientRequest Contains information for calling an API on the middle-tier server.
  */
  function switchToFallbackAuth(clientRequest) {
-// TODO 11: Get a new client request to use MSAL.
+// TODO 10: Get a new client request to use MSAL.
 }

--- a/Samples/auth/Office-Add-in-NodeJS-SSO/Begin/public/javascripts/ssoAuthES6.js
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/Begin/public/javascripts/ssoAuthES6.js
@@ -92,10 +92,6 @@ Office.onReady(function (info) {
     
     // TODO 7: Call REST API with error handler.
 
-    // TODO 8: Check for expired SSO token and refresh if needed.
-
-    // TODO 9: Check for Microsoft Graph and other errors.
-
   }
 
 /**

--- a/Samples/auth/Office-Add-in-NodeJS-SSO/Begin/routes/getFilesRoute.js
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/Begin/routes/getFilesRoute.js
@@ -7,7 +7,7 @@ const authHelper = require("../server-helpers/obo-auth-helper");
 const getGraphData = require("../server-helpers/msgraph-helper");
 const jwt = require("jsonwebtoken");
 
-// TODO 12: Add route for /getuserfilenames REST API
+// TODO 11: Add route for /getuserfilenames REST API
 
 
 module.exports = router;

--- a/Samples/auth/Office-Add-in-NodeJS-SSO/Begin/views/layout.pug
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/Begin/views/layout.pug
@@ -18,6 +18,8 @@ html
     script(src='/javascripts/document.js')
     script(src='/javascripts/message-helper.js')
     script(src='/javascripts/ssoAuthEs6.js')
+    script(src='/javascripts/fallback-msal/authConfig.js')
     script(src='/javascripts/fallback-msal/fallbackAuthTaskpane.js')
+    
   body.ms-font-m.cancelDefaultBrowserIndentation
     block content

--- a/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/public/javascripts/fallback-msal/authRedirect.js
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/public/javascripts/fallback-msal/authRedirect.js
@@ -24,7 +24,7 @@ function handleResponse(response) {
 
   if (response !== null) {
     Office.context.ui.messageParent(
-      JSON.stringify({ status: "success", result: response.accessToken }),
+      JSON.stringify({ status: "success", result: response.accessToken, accountId: response.account.homeAccountId }),
       { targetOrigin: window.location.origin }
     );
   } else {

--- a/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/public/javascripts/fallback-msal/fallbackAuthTaskpane.js
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/public/javascripts/fallback-msal/fallbackAuthTaskpane.js
@@ -15,8 +15,8 @@ async function dialogFallback(clientRequest) {
   if (homeAccountId !== null) {
     const result = await myMSALObj.acquireTokenSilent(loginRequest);
     if (result !== null && result.accessToken !== null) {
-      clientRequest.accessToken = result.accessToken;
-      clientRequest.callbackFunction(storedClientRequest);
+      clientRequest.accessToken = result.accessToken;    
+      clientRequest.callbackFunction(clientRequest);
     }
   } else {
     // Pop up dialog to sign in user.

--- a/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/public/javascripts/fallback-msal/fallbackAuthTaskpane.js
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/public/javascripts/fallback-msal/fallbackAuthTaskpane.js
@@ -3,46 +3,77 @@
 
 // This file shows how to open a dialog and process any results sent back to the task pane.
 
-var loginDialog;
+let loginDialog = null;
+let homeAccountId = null;
 let storedCallbackFunction = null;
 let storedClientRequest = null;
 
-function dialogFallback(clientRequest) {
+const myMSALObj = new msal.PublicClientApplication(msalConfig);
+
+async function dialogFallback(clientRequest) {
+  // Attempt to acquire token silently if user is already signed in.
+  if (homeAccountId !== null) {
+    const result = await myMSALObj.acquireTokenSilent(loginRequest);
+    if (result !== null && result.accessToken !== null) {
+      clientRequest.accessToken = result.accessToken;
+      clientRequest.callbackFunction(storedClientRequest);
+    }
+  } else {
+    // Pop up dialog to sign in user.
     storedClientRequest = clientRequest;
-    var url = "/dialog.html"; 
-	showLoginPopup(url);
+    const url = "/dialog.html";
+    showLoginPopup(url);
+  }
 }
 
 // This handler responds to the success or failure message that the pop-up dialog receives from the identity provider
 // and access token provider.
 function processMessage(arg) {
+  console.log("Message received in processMessage");
+  let messageFromDialog = JSON.parse(arg.message);
 
-    console.log("Message received in processMessage");
-    let messageFromDialog = JSON.parse(arg.message);
+  if (messageFromDialog.status === "success") {
+    // We now have a valid access token.
+    loginDialog.close();
 
-        if (messageFromDialog.status === 'success') { 
-            // We now have a valid access token.
-            loginDialog.close();
-            storedClientRequest.accessToken = messageFromDialog.result;
-            storedClientRequest.callbackFunction(storedClientRequest);
-            //makeGraphApiCall(messageFromDialog.result);
-        }
-        else {
-            // Something went wrong with authentication or the authorization of the web application.
-            loginDialog.close();
-            showMessage(JSON.stringify(error.toString()));
-        }
+    homeAccountId = messageFromDialog.accountId; // Track the account id for future silent token requests.
+
+    // Configure MSAL to use the signed-in account as the active account for future requests.
+    const homeAccount = myMSALObj.getAccountByHomeId(
+      messageFromDialog.accountId
+    );
+    myMSALObj.setActiveAccount(homeAccount);
+
+    // Add access token to the client request and run the callback function.
+    storedClientRequest.accessToken = messageFromDialog.result;
+    storedClientRequest.callbackFunction(storedClientRequest);
+  } else {
+    // Something went wrong with authentication or the authorization of the web application.
+    loginDialog.close();
+    showMessage(JSON.stringify(error.toString()));
+  }
 }
 
 // Use the Office dialog API to open a pop-up and display the sign-in page for the identity provider.
 function showLoginPopup(url) {
-	var fullUrl = location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '') + url;
+  var fullUrl =
+    location.protocol +
+    "//" +
+    location.hostname +
+    (location.port ? ":" + location.port : "") +
+    url;
 
-	// height and width are percentages of the size of the parent Office application, e.g., PowerPoint, Excel, Word, etc.
-	Office.context.ui.displayDialogAsync(fullUrl,
-		{ height: 60, width: 30 }, function (result) {
-			console.log("Dialog has initialized. Wiring up events");
-			loginDialog = result.value;
-			loginDialog.addEventHandler(Office.EventType.DialogMessageReceived, processMessage);
-		});
+  // height and width are percentages of the size of the parent Office application, e.g., PowerPoint, Excel, Word, etc.
+  Office.context.ui.displayDialogAsync(
+    fullUrl,
+    { height: 60, width: 30 },
+    function (result) {
+      console.log("Dialog has initialized. Wiring up events");
+      loginDialog = result.value;
+      loginDialog.addEventHandler(
+        Office.EventType.DialogMessageReceived,
+        processMessage
+      );
+    }
+  );
 }

--- a/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/public/javascripts/ssoAuthES6.js
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/public/javascripts/ssoAuthES6.js
@@ -3,7 +3,7 @@
 
 // global to track if we are using SSO or the fallback auth.
 // To test fallback auth, set authSSO = false.
-let authSSO = true;
+let authSSO = false;
 
 // If the add-in is running in Internet Explorer, the code must add support
 // for Promises.
@@ -19,13 +19,14 @@ Office.onReady(function (info) {
 
 /**
  * Handles the click event for the Get File Name List button.
- * Requests a call to the middle-tier server /getuserfilenames that
+ * Requests a call to the ASP.NET Core server /api/filenames REST API that
  * gets up to 10 file names listed in the user's OneDrive.
  * When the call is completed, it will call the clientRequest.callbackRESTApiHandler.
  */
 function getFileNameList() {
   clearMessage(); // Clear message log on task pane each time an API runs.
   createRequest(
+    "GET",
     "/getuserfilenames",
     handleGetFileNameResponse,
     async (clientRequest) => {
@@ -35,13 +36,13 @@ function getFileNameList() {
 }
 
 /**
- * Handler for the returned response from the middle-tier server API call to get file names.
+ * Handler for the returned response from the ASP.NET Core server API call to get file names.
  * Writes out the file names to the document.
  *
  * @param {*} response The list of file names.
  */
 async function handleGetFileNameResponse(response) {
-  if (response != null) {
+  if (response !== null) {
     try {
       await writeFileNamesToOfficeDocument(response);
       showMessage("Your OneDrive filenames are added to the document.");
@@ -55,71 +56,71 @@ async function handleGetFileNameResponse(response) {
 }
 
 /**
- * Calls the REST API on the middle-tier server. Error handling will
+ * Calls the REST API on the server. Error handling will
  * switch to fallback auth if SSO fails.
  *
- * @param {*} clientRequest Contains information for calling an API on the middle-tier server.
+ * @param {*} clientRequest Contains information for calling an API on the server.
  */
 async function callWebServer(clientRequest) {
   try {
-    await ajaxCallToRESTApi(clientRequest);
-  } catch (error) {
-    if (error.statusText === "Internal Server Error") {
-      const retryCall = handleWebServerErrors(error, clientRequest);
-      if (retryCall && clientRequest.authSSO) {
-        try {
-          clientRequest.accessToken = await getAccessTokenFromSSO(
-            clientRequest.authOptions
-          );
-          await ajaxCallToRESTApi(clientRequest);
-        } catch {
-          // If still an error go to fallback.
-          switchToFallbackAuth(clientRequest);
-          return;
-        }
-      }
-    } else {
-      console.log(JSON.stringify(error)); // Log any errors.
-      showMessage(error.responseText);
-    }
-  }
-}
-
-/**
- * Makes the AJAX call to the REST API in the middle-tier server.
- * Note that any errors are thrown to the caller to handle.
- * @param {} clientRequest Contains information for calling an API on the middle-tier server.
- */
-async function ajaxCallToRESTApi(clientRequest) {
-  try {
-    await $.ajax({
-      type: "GET",
+    const data = await $.ajax({
+      type: clientRequest.verb,
       url: clientRequest.url,
       headers: { Authorization: "Bearer " + clientRequest.accessToken },
       cache: false,
-      success: function (data) {
-        result = data;
-        // Send result to the callback handler.
-        clientRequest.callbackRESTApiHandler(result);
-      },
     });
+    clientRequest.callbackRESTApiHandler(data);
   } catch (error) {
-    // This function explicitly requires the caller to handle any errors
-    throw error;
+    // Check for expired token. Refresh and retry the call if it expired.
+    if (error.responseJSON.type === "AADSTS500133") {
+      try {
+        clientRequest.accessToken = await Office.auth.getAccessToken(
+          clientRequest.authOptions
+        );
+        const data = await $.ajax({
+          type: clientRequest.verb,
+          url: clientRequest.url,
+          headers: { Authorization: "Bearer " + clientRequest.accessToken },
+          cache: false,
+        });
+        clientRequest.callbackRESTApiHandler(data);
+      } catch (error) {
+        showMessage(error.responseText);
+        switchToFallbackAuth(clientRequest);
+        return;
+      }
+    }
+
+    // Check for a Microsoft Graph API call error. which is returned as bad request (403)
+    if (error.status === 403) {
+      showMessage(error.responseJSON.errorDetails);
+      return;
+    }
+
+    // For all other error scenarios, display the message and use fallback auth.
+    showMessage(
+      "Unknown error from web server: " +
+        JSON.stringify(error.responseJSON.errorDetails)
+    );
+    if (clientRequest.authSSO) switchToFallbackAuth(clientRequest);
   }
 }
 
 /**
- * Switches the client request to use MSAL auth (fallback) instead of SSO.
- * Once the new client request is created with MSAL access token, callWebServer is called
+ * Switches the client request to use MSAL.js auth (fallback) instead of SSO.
+ * Once the new client request is created with MSAL.js access token, callWebServer is called
  * to continue attempting to call the REST API.
- * @param {*} clientRequest Contains information for calling an API on the middle-tier server.
+ * @param {*} clientRequest Contains information for calling an API on the server.
  */
 function switchToFallbackAuth(clientRequest) {
+  // Guard against accidental call to this function when fallback is already in use.
+  if (authSSO === false) return;
+
   showMessage("Switching from SSO to fallback auth.");
   authSSO = false;
   // Create a new request for fallback auth.
   createRequest(
+    clientRequest.verb,
     clientRequest.url,
     clientRequest.callbackRESTApiHandler,
     async (fallbackRequest) => {
@@ -133,8 +134,9 @@ function switchToFallbackAuth(clientRequest) {
  * Creates a client request object with:
  * authOptions - Auth configuration parameters for SSO.
  * authSSO - true if using SSO, otherwise false.
- * accessToken - The access token to the middle-tier server.
- * url - The URL of the REST API to call on the middle-tier server.
+ * verb - REST API verb such as GET, POST...
+ * accessToken - The access token to the ASP.NET Core server.
+ * url - The URL of the REST API to call on the ASP.NET Core server.
  * callbackRESTApiHandler - The function to pass the results of the REST API call.
  * callbackFunction - the function to pass the client request to when ready.
  *
@@ -143,7 +145,7 @@ function switchToFallbackAuth(clientRequest) {
  *
  * @param {*} callbackFunction The function to pass the client request to when ready.
  */
-async function createRequest(url, restApiCallback, callbackFunction) {
+async function createRequest(verb, url, restApiCallback, callbackFunction) {
   const clientRequest = {
     authOptions: {
       allowSignInPrompt: true,
@@ -151,48 +153,28 @@ async function createRequest(url, restApiCallback, callbackFunction) {
       forMSGraphAccess: true,
     },
     authSSO: authSSO,
+    verb: verb,
     accessToken: null,
     url: url,
     callbackRESTApiHandler: restApiCallback,
     callbackFunction: callbackFunction,
   };
 
-  // Get access token.
   if (authSSO) {
     try {
       // Get access token from Office SSO.
-      clientRequest.accessToken = await getAccessTokenFromSSO(
+      clientRequest.accessToken = await Office.auth.getAccessToken(
         clientRequest.authOptions
       );
       callbackFunction(clientRequest);
-    } catch {
-      // use fallback auth if SSO failed to get access token.
-      switchToFallbackAuth(clientRequest);
+    } catch (error) {
+      // handle the SSO error which will inform us if we need to switch to fallback auth.
+      let fallbackRequired = handleSSOErrors(error);
+      if (fallbackRequired) switchToFallbackAuth(clientRequest);
     }
   } else {
     // Use fallback auth to get access token.
     dialogFallback(clientRequest);
-  }
-}
-
-/**
- * Returns the access token for using SSO auth. Throws an error if SSO fails.
- * @param {*} authOptions The configuration options for SSO.
- * @returns An access token to the middle-tier server for the signed in user.
- */
-async function getAccessTokenFromSSO(authOptions) {
-  if (authOptions === undefined) throw Error("authOptions parameter missing.");
-
-  try {
-    // The access token returned from getAccessToken only has permissions to your middle-tier server APIs,
-    // and it contains the identity claims of the signed-in user.
-
-    const accessToken = await Office.auth.getAccessToken(authOptions);
-    return accessToken;
-  } catch (error) {
-    let fallbackRequired = handleSSOErrors(error);
-    if (fallbackRequired) throw error; // Rethrow the error and caller will switch to fallback auth.
-    return null; // Returning a null token indicates no need for fallback (an explanation about the error condition was shown by handleSSOErrors).
   }
 }
 
@@ -249,44 +231,4 @@ function handleSSOErrors(err) {
       break;
   }
   return fallbackRequired;
-}
-
-/**
- * Handles any error returned from the middle-tier server.
- * @param {*} err The error to process.
- * @returns {boolean} true if the caller should try the REST API again; otherwise false.
- */
-function handleWebServerErrors(err, clientRequest) {
-  let retryCall = false;
-  // Our middle-tier server returns a type to help handle the known cases.
-  switch (err.responseJSON.type) {
-    case "Microsoft Graph":
-      // An error occurred when the middle-tier server called Microsoft Graph.
-      showMessage(
-        "Error from Microsoft Graph: " +
-          JSON.stringify(err.responseJSON.errorDetails)
-      );
-      retryCall = false;
-      break;
-    case "Missing access_as_user":
-      // The access_as_user scope was missing.
-      showMessage("Error: Access token is missing the access_as_user scope.");
-      retryCall = false;
-      break;
-    case "AADSTS500133": // expired token
-      // On rare occasions the access token could expire after it was sent to the middle-tier server.
-      // Microsoft identity platform will respond with
-      // "The provided value for the 'assertion' is not valid. The assertion has expired."
-      // Return true to indicate to caller they should refresh the token.
-      retryCall = true;
-      break;
-    default:
-      showMessage(
-        "Unknown error from web server: " +
-          JSON.stringify(err.responseJSON.errorDetails)
-      );
-      retryCall = false;
-      if (clientRequest.authSSO) switchToFallbackAuth(clientRequest);
-  }
-  return retryCall;
 }

--- a/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/public/javascripts/ssoAuthES6.js
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/public/javascripts/ssoAuthES6.js
@@ -3,7 +3,7 @@
 
 // global to track if we are using SSO or the fallback auth.
 // To test fallback auth, set authSSO = false.
-let authSSO = false;
+let authSSO = true;
 
 // If the add-in is running in Internet Explorer, the code must add support
 // for Promises.

--- a/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/routes/getFilesRoute.js
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/routes/getFilesRoute.js
@@ -15,18 +15,18 @@ router.get(
       const authHeader = req.headers.authorization;
       let oboRequest = {
         oboAssertion: authHeader.split(" ")[1],
-        scopes: ["files.read"]
+        scopes: ["files.read"],
       };
 
       // The Scope claim tells you what permissions the client application has in the service.
       // In this case we look for a scope value of access_as_user, or full access to the service as the user.
       const tokenScopes = jwt.decode(oboRequest.oboAssertion).scp.split(" ");
-      const accessAsUserScope = tokenScopes.find(scope => scope === 'access_as_user');
-      if (!accessAsUserScope){
-        res
-          .status(401)
-          .send({ type: "Missing access_as_user"});
-          return;
+      const accessAsUserScope = tokenScopes.find(
+        (scope) => scope === "access_as_user"
+      );
+      if (!accessAsUserScope) {
+        res.status(401).send({ type: "Missing access_as_user" });
+        return;
       }
       const cca = authHelper.getConfidentialClientApplication();
       const response = await cca.acquireTokenOnBehalfOf(oboRequest);
@@ -39,7 +39,11 @@ router.get(
       // sanitized so that it cannot be used in a Response header injection attack.
       const params = "?$select=name&$top=10";
 
-      const graphData = await getGraphData(response.accessToken, rootUrl, params);
+      const graphData = await getGraphData(
+        response.accessToken,
+        rootUrl,
+        params
+      );
 
       // If Microsoft Graph returns an error, such as invalid or expired token,
       // there will be a code property in the returned object set to a HTTP status (e.g. 401).
@@ -47,7 +51,12 @@ router.get(
       if (graphData.code) {
         res
           .status(403)
-          .send({ type: "Microsoft Graph", errorDetails: "An error occurred while calling the Microsoft Graph API.\n" + graphData });
+          .send({
+            type: "Microsoft Graph",
+            errorDetails:
+              "An error occurred while calling the Microsoft Graph API.\n" +
+              graphData,
+          });
       } else {
         // MS Graph data includes OData metadata and eTags that we don't need.
         // Send only what is actually needed to the client: the item names.
@@ -65,9 +74,9 @@ router.get(
       // with "The provided value for the 'assertion' is not valid. The assertion has expired."
       // Construct an error message to return to the client so it can refresh the SSO token.
       if (err.errorMessage.indexOf("AADSTS500133") !== -1) {
-        res.status(401).send({ type: "AADSTS500133", errorDetails: err });
+        res.status(401).send({ type: "TokenExpiredError", errorDetails: err });
       } else {
-        res.status(401).send({ type: "Unknown", errorDetails: err });
+        res.status(403).send({ type: "Unknown", errorDetails: err });
       }
     }
   }

--- a/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/routes/getFilesRoute.js
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/routes/getFilesRoute.js
@@ -46,8 +46,8 @@ router.get(
       // Return it to the client. On client side it will get handled in the fail callback of `makeWebServerApiCall`.
       if (graphData.code) {
         res
-          .status(500)
-          .send({ type: "Microsoft Graph", errorDetails: graphData });
+          .status(403)
+          .send({ type: "Microsoft Graph", errorDetails: "An error occurred while calling the Microsoft Graph API.\n" + graphData });
       } else {
         // MS Graph data includes OData metadata and eTags that we don't need.
         // Send only what is actually needed to the client: the item names.
@@ -65,9 +65,9 @@ router.get(
       // with "The provided value for the 'assertion' is not valid. The assertion has expired."
       // Construct an error message to return to the client so it can refresh the SSO token.
       if (err.errorMessage.indexOf("AADSTS500133") !== -1) {
-        res.status(500).send({ type: "AADSTS500133", errorDetails: err });
+        res.status(401).send({ type: "AADSTS500133", errorDetails: err });
       } else {
-        res.status(500).send({ type: "Unknown", errorDetails: err });
+        res.status(401).send({ type: "Unknown", errorDetails: err });
       }
     }
   }

--- a/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/views/layout.pug
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/views/layout.pug
@@ -18,6 +18,8 @@ html
     script(src='/javascripts/document.js')
     script(src='/javascripts/message-helper.js')
     script(src='/javascripts/ssoAuthEs6.js')
+    script(src='/javascripts/fallback-msal/authConfig.js')
     script(src='/javascripts/fallback-msal/fallbackAuthTaskpane.js')
+    
   body.ms-font-m.cancelDefaultBrowserIndentation
     block content


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                               |
| New feature?    | no                              |
| New sample?     | no                                |
| Related issues? | NA |

## What's in this Pull Request?
This updates the code for fallback auth to use the MSAL cache to acquire the access token. This avoids popping up a dialog to sign in the user on every single REST API call.
