### PR TITLE
[Word OOXML sample] fix style with text XML

### DIFF
--- a/Samples/word-add-in-load-and-write-open-xml/C#/LoadingAndWritingOOXMLWeb/OOXMLSamples/TextWithStyle.xml
+++ b/Samples/word-add-in-load-and-write-open-xml/C#/LoadingAndWritingOOXMLWeb/OOXMLSamples/TextWithStyle.xml
@@ -22,9 +22,10 @@
               <w:pStyle w:val="Heading1"/>
             </w:pPr>
             <w:r>
-              <w:t>This text is formatted using the Heading 1 paragraph style.</w:t>
+              <w:t>This text is formatted using the Heading 1 paragraph style..</w:t>
             </w:r>
           </w:p>
+          <w:p/>
         </w:body>
       </w:document>
     </pkg:xmlData>


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                              |
| New feature?    | no                                |
| New sample?     | no                                |
| Related issues? | none |

## What's in this Pull Request?

The XML for the style with text option was missing a paragraph. This update makes it work.