### PR TITLE
[Data types explorer] Promote sample from preview to GA after release of ExcelApi 1.16

### DIFF
--- a/Samples/excel-data-types-explorer/README.md
+++ b/Samples/excel-data-types-explorer/README.md
@@ -14,15 +14,11 @@ extensions:
 description: "Create data types in Excel workbooks and explore existing data types in Excel workbooks."
 ---
 
-# Create and explore data types in Excel (preview)
+# Create and explore data types in Excel
 
 ## Summary
 
-This sample builds an Excel add-in that can create and explore data types in your workbooks. Data types enable add-in developers to organize complex data structures as objects, such as formatted number values, web images, and entity values. See [Overview of data types in Excel add-ins (preview)](https://docs.microsoft.com/office/dev/add-ins/excel/excel-data-types-overview) to learn more about data types.
-
-> **Note:** Data types APIs are currently only available in public preview. Preview APIs are subject to change and are not intended for use in a production environment. We recommend that you try them out in test and development environments only. Do not use preview APIs in a production environment or within business-critical documents. This add-in sample references the **beta** Office.js library on the content delivery network (CDN) (https://appsforoffice.microsoft.com/lib/beta/hosted/office.js) and the **beta** [type definition file](https://appsforoffice.microsoft.com/lib/beta/hosted/office.d.ts) for TypeScript compilation and IntelliSense.
->
-> To try out data types in Office on Windows, you must have an Excel build number greater than or equal to 16.0.14626.10000. To try out data types in Office on Mac, you must have an Excel build number greater than or equal to 16.55.21102600.
+This sample builds an Excel add-in that can create and explore data types in your workbooks. Data types enable add-in developers to organize complex data structures as objects, such as formatted number values, web images, and entity values. See [Overview of data types in Excel add-ins](https://docs.microsoft.com/office/dev/add-ins/excel/excel-data-types-overview) to learn more about data types.
 
 ## Features
 

--- a/Samples/excel-data-types-explorer/README.md
+++ b/Samples/excel-data-types-explorer/README.md
@@ -18,7 +18,7 @@ description: "Create data types in Excel workbooks and explore existing data typ
 
 ## Summary
 
-This sample builds an Excel add-in that can create and explore data types in your workbooks. Data types enable add-in developers to organize complex data structures as objects, such as formatted number values, web images, and entity values. See [Overview of data types in Excel add-ins](https://docs.microsoft.com/office/dev/add-ins/excel/excel-data-types-overview) to learn more about data types.
+This sample builds an Excel add-in that can create and explore data types in your workbooks. Data types enable add-in developers to organize complex data structures as objects, such as formatted number values, web images, and entities. See [Overview of data types in Excel add-ins](https://docs.microsoft.com/office/dev/add-ins/excel/excel-data-types-overview) to learn more about data types.
 
 ## Features
 
@@ -53,6 +53,7 @@ Create and explore data types in Excel workbooks | Microsoft
 Version  | Date | Comments
 ---------| -----| --------
 1.0 | 9-7-2022 | Initial release
+1.1 | 10-12-2022 | Promote from Preview to GA
 
 ----------
 

--- a/Samples/excel-data-types-explorer/package-lock.json
+++ b/Samples/excel-data-types-explorer/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@babel/core": "^7.13.10",
         "@babel/preset-typescript": "^7.13.0",
-        "@types/jquery": "^3.3.1",
+        "@types/jquery": "^3.5.0",
         "@types/office-js": "^1.0.108",
         "@types/office-runtime": "^1.0.23",
         "acorn": "^8.5.0",
@@ -2563,10 +2563,13 @@
       }
     },
     "node_modules/@types/jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-N3h+rzN518yl2xKrW0o6KKdNmWZ+OwG6SoM5TBEQFF0tTv5wXPEsoOuYQ2Kt3/89XbcSZUJLdjiT/2c3BR/ApQ==",
-      "dev": true
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
+      "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
+      "dev": true,
+      "dependencies": {
+        "@types/sizzle": "*"
+      }
     },
     "node_modules/@types/json-buffer": {
       "version": "3.0.0",
@@ -2693,6 +2696,12 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "dev": true
     },
     "node_modules/@types/sockjs": {
       "version": "0.3.33",
@@ -16158,10 +16167,13 @@
       }
     },
     "@types/jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-N3h+rzN518yl2xKrW0o6KKdNmWZ+OwG6SoM5TBEQFF0tTv5wXPEsoOuYQ2Kt3/89XbcSZUJLdjiT/2c3BR/ApQ==",
-      "dev": true
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
+      "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
+      "dev": true,
+      "requires": {
+        "@types/sizzle": "*"
+      }
     },
     "@types/json-buffer": {
       "version": "3.0.0",
@@ -16287,6 +16299,12 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "@types/sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+      "dev": true
     },
     "@types/sockjs": {
       "version": "0.3.33",

--- a/Samples/excel-data-types-explorer/package-lock.json
+++ b/Samples/excel-data-types-explorer/package-lock.json
@@ -16,7 +16,7 @@
         "@babel/core": "^7.13.10",
         "@babel/preset-typescript": "^7.13.0",
         "@types/jquery": "^3.3.1",
-        "@types/office-js-preview": "^1.0.330",
+        "@types/office-js": "^1.0.108",
         "@types/office-runtime": "^1.0.23",
         "acorn": "^8.5.0",
         "babel-loader": "^8.2.2",
@@ -2627,10 +2627,10 @@
         "form-data": "^3.0.0"
       }
     },
-    "node_modules/@types/office-js-preview": {
-      "version": "1.0.330",
-      "resolved": "https://registry.npmjs.org/@types/office-js-preview/-/office-js-preview-1.0.330.tgz",
-      "integrity": "sha512-ufJ+JD8WgLcpR4mjTMs1ObUkBVl7cD5D6LXZx/p7L/Bp9EVh3+Vklno7aslVHTb4uBcTxqDKrVrDjWZahvfZsQ==",
+    "node_modules/@types/office-js": {
+      "version": "1.0.290",
+      "resolved": "https://registry.npmjs.org/@types/office-js/-/office-js-1.0.290.tgz",
+      "integrity": "sha512-O9jdGNHOjPO8YtTXm7cUM6f3m/23nru66m14cPv/rHOpDMBn2Q5eWWm65wwRNbEL9ki8/RuSd9nK9LNgIKHZ2A==",
       "dev": true
     },
     "node_modules/@types/office-runtime": {
@@ -16221,10 +16221,10 @@
         "form-data": "^3.0.0"
       }
     },
-    "@types/office-js-preview": {
-      "version": "1.0.330",
-      "resolved": "https://registry.npmjs.org/@types/office-js-preview/-/office-js-preview-1.0.330.tgz",
-      "integrity": "sha512-ufJ+JD8WgLcpR4mjTMs1ObUkBVl7cD5D6LXZx/p7L/Bp9EVh3+Vklno7aslVHTb4uBcTxqDKrVrDjWZahvfZsQ==",
+    "@types/office-js": {
+      "version": "1.0.290",
+      "resolved": "https://registry.npmjs.org/@types/office-js/-/office-js-1.0.290.tgz",
+      "integrity": "sha512-O9jdGNHOjPO8YtTXm7cUM6f3m/23nru66m14cPv/rHOpDMBn2Q5eWWm65wwRNbEL9ki8/RuSd9nK9LNgIKHZ2A==",
       "dev": true
     },
     "@types/office-runtime": {

--- a/Samples/excel-data-types-explorer/package.json
+++ b/Samples/excel-data-types-explorer/package.json
@@ -33,7 +33,7 @@
     "@babel/core": "^7.13.10",
     "@babel/preset-typescript": "^7.13.0",
     "@types/jquery": "^3.3.1",
-    "@types/office-js-preview": "^1.0.330",
+    "@types/office-js": "^1.0.108",
     "@types/office-runtime": "^1.0.23",
     "acorn": "^8.5.0",
     "babel-loader": "^8.2.2",

--- a/Samples/excel-data-types-explorer/package.json
+++ b/Samples/excel-data-types-explorer/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@babel/core": "^7.13.10",
     "@babel/preset-typescript": "^7.13.0",
-    "@types/jquery": "^3.3.1",
+    "@types/jquery": "^3.5.0",
     "@types/office-js": "^1.0.108",
     "@types/office-runtime": "^1.0.23",
     "acorn": "^8.5.0",

--- a/Samples/excel-data-types-explorer/src/taskpane/taskpane.html
+++ b/Samples/excel-data-types-explorer/src/taskpane/taskpane.html
@@ -10,8 +10,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Office Add-ins Excel Data Types Explorer</title>
 
-    <!-- Office Preview JavaScript API -->
-    <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/beta/hosted/office.js"></script>
+    <!-- Office JavaScript API -->
+    <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js"></script>
 
     <!-- For more information on Fluent UI, visit https://developer.microsoft.com/fluentui#/. -->
     <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/11.0.0/css/fabric.min.css"/>

--- a/Samples/excel-data-types-explorer/src/taskpane/taskpane.ts
+++ b/Samples/excel-data-types-explorer/src/taskpane/taskpane.ts
@@ -358,53 +358,7 @@ function entityContent(): JQuery<HTMLElement> {
   let iconlabel = $(`<label class="labels"> Entity icon: </label>`);
   let contentLabel = $(`<label class="labels contentPadding">Entity contents:</label>`);
   let select = $(`<select id="iconSelect" name="dataType" class="ms-Button ms-Button-label buttons"/>`);
-  let options = createOptionsFromList([
-    "Generic",
-    "Airplane",
-    "Animal",
-    "Apple",
-    "Art",
-    "Atom",
-    "Bank",
-    "Basketball",
-    "Beaker",
-    "Bird",
-    "Book",
-    "Bridge",
-    "Briefcase",
-    "Car",
-    "Cat",
-    "City",
-    "Clouds",
-    "Constellation",
-    "Dinosaur",
-    "Disaster",
-    "DNA",
-    "Dog",
-    "Drama",
-    "Galaxy",
-    "HatGraduation",
-    "Heart",
-    "Languages",
-    "Leaf",
-    "Location",
-    "Map",
-    "Microscope",
-    "Money",
-    "Mountain",
-    "MovieCamera",
-    "MusicNote",
-    "Notebook",
-    "PartlySunnyWeather",
-    "Person",
-    "Planet",
-    "PointScan",
-    "Running",
-    "Satellite",
-    "Syringe",
-    "Violin",
-    "Wand"
-  ]);
+  let options = createOptionsFromList(Object.values(Excel.EntityCompactLayoutIcons));
 
   for (let i = 0; i < options.length; ++i) {
     select.append(options[i]);


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                              |
| New feature?    | no                               |
| New sample?     | no                              |
| Related issues? |  #393 |

## What's in this Pull Request?

ExcelApi 1.16 has been released to GA. This PR updates the Data types explorer sample, removing the references to the office-js-preview type definitions and replacing them with office-js type definitions. 

This PR also incorporates the dependabot update to jQuery from PR #393, and switches the icon list in taskpane.ts from a static list to an enum-generated list.