### PR TITLE
[Outlook] (Smart Alerts sample) Clarify when categories are viewable from a message in compose mode

### DIFF
--- a/Samples/outlook-check-item-categories/README.md
+++ b/Samples/outlook-check-item-categories/README.md
@@ -117,6 +117,8 @@ Once the add-in is loaded, use the following steps to try out its functionality.
 
     The applied categories appear in the **Categories applied** section of the task pane.
 
+    **Note**: Categories applied to a message being composed don't appear on the message itself. They only appear on the message once the message is sent and is accessed from the **Sent Items** folder.
+
 1. Send the message or appointment.
 
 ## Run the sample from localhost


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                          |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? | none|

## What's in this Pull Request?

Clarifies that categories applied to a message in compose mode are only viewable from the message once the message is sent and is accessed from the Sent Items folder.

## Guidance

N/A