### PR TITLE
correct JSON schema URI and remove property unsupported in Outlook

### DIFF
--- a/Samples/outlook-set-signature/manifest.json
+++ b/Samples/outlook-set-signature/manifest.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/op/extensions/MicrosoftTeams.schema.json",
+    "$schema": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
     "id": "B341AD31-BF7A-4C1D-99F1-D2E5896BEB0A",
     "version": "1.0.0.0",
@@ -133,7 +133,6 @@
                             "builtInTabId": "TabDefault",
                             "groups": [
                                 {
-                                    "overriddenByRibbonApi": false,
                                     "id": "mccsG0",
                                     "label": "Signature Injector",
                                     "controls": [

--- a/Samples/outlook-set-signature/manifest.json
+++ b/Samples/outlook-set-signature/manifest.json
@@ -191,7 +191,6 @@
                             "builtInTabId": "TabDefault",
                             "groups": [
                                 {
-                                    "overriddenByRibbonApi": false,
                                     "id": "aocsG0",
                                     "label": "Signature Injector2",
                                     "controls": [


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                              |
| New feature?    | no                            |
| New sample?     | no                            |
| Related issues? | fixes #X, partially #Y, mentioned in #Z |

## What's in this Pull Request?

Updates the URI for the JSON manifest schema.
Removes a JSON property that is not supported in Outlook.

## Guidance

