### PR TITLE
Fix check for "access_as_user" in NodeJS SSO example

### DIFF
--- a/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/routes/getFilesRoute.js
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/Complete/routes/getFilesRoute.js
@@ -22,9 +22,9 @@ router.get(
       // In this case we look for a scope value of access_as_user, or full access to the service as the user.
       const tokenScopes = jwt.decode(oboRequest.oboAssertion).scp.split(' ');
       let accessAsUserScope = tokenScopes.find(
-        (scope) => scope === 'access_as_user'
+        (scope) => scope === 'access_as_users'
       );
-      if (accessAsUserScope !== 'access_as_user' ) {
+      if (accessAsUserScope !== 'access_as_users' ) {
         res.status(401).send({ type: "Missing access_as_user" });
         return;
       }


### PR DESCRIPTION
since tokenScopes returns "access_as_users", this checks will always fail since they are looking for "access_as_user".

|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                               |
| New feature?    | no - yes?                               |
| New sample?     | no - yes?                               |
| Related issues? |Fixes #756  |

## What's in this Pull Request?

Fixed the check provided in the `complete` directory.

## Guidance
Refering to [Create a Node.js Office Add-in that uses single sign-on](https://learn.microsoft.com/en-us/office/dev/add-ins/develop/create-sso-office-add-ins-nodejs)
Since const `tokenScopes` returns "access_as_users", the checks in `Create the route and implement On-Behalf-Of flow | TODO 10` would always fail.