### PR TITLE
Consume getAuthContext for Outlook NAA sample and add logging

### DIFF
--- a/Samples/auth/Outlook-Add-in-SSO-NAA/src/taskpane/taskpane.ts
+++ b/Samples/auth/Outlook-Add-in-SSO-NAA/src/taskpane/taskpane.ts
@@ -28,9 +28,8 @@ Office.onReady((info) => {
     }
 
     // Initialize MSAL. MSAL need's a loginHint for when running in a browser.
-    const accountType = Office.context.mailbox.userProfile.accountType;
-    const loginHint = (accountType === "office365" || accountType === "outlookCom") ? Office.context.mailbox.userProfile.emailAddress : "";
-    accountManager.initialize(loginHint);
+
+    accountManager.initialize();
   }
 });
 


### PR DESCRIPTION
Consome getAuthContext API in Outlook to help initialize MSAL.js (get loginHint, and filter to correct account in cache). Also implement loggerOptions behind a flag that can be used to help diagnose MSAL.js errors. The following line can be changed for additional logging: `this.pca = await PublicClientNext.createPublicClientApplication(getMsalConfig(true))`