### PR TITLE
[Outlook] (spam reporting) Add Office.onReady function

### DIFF
--- a/Samples/outlook-spam-reporting/src/spamreporting.js
+++ b/Samples/outlook-spam-reporting/src/spamreporting.js
@@ -3,6 +3,16 @@
  * Licensed under the MIT license.
  */
 
+// Ensures the Office.js library is loaded.
+Office.onReady(() => {
+  /**
+   * IMPORTANT: To ensure your add-in is supported in the classic Outlook client on Windows,
+   * remember to map the event handler name specified in the manifest to its JavaScript counterpart.
+   */
+  if (Office.context.platform === Office.PlatformType.PC || Office.context.platform == null) {
+    Office.actions.associate("onSpamReport", onSpamReport); }
+});
+
 // Handles the SpamReporting event to process a reported message.
 function onSpamReport(event) {
   // Get the Base64-encoded EML format of a reported message.
@@ -23,7 +33,13 @@ function onSpamReport(event) {
 
       // Run additional processing operations here.
 
-      /* Signals that the spam-reporting event has completed processing. It then moves the reported message to the Junk Email folder of the mailbox, then shows a post-processing dialog to the user. If an error occurs while the message is being processed, the `onErrorDeleteItem` property determines whether the message will be deleted. */
+      /**
+       * Signals that the spam-reporting event has completed processing.
+       * It then moves the reported message to the Junk Email folder of the mailbox,
+       * then shows a post-processing dialog to the user.
+       * If an error occurs while the message is being processed,
+       * the `onErrorDeleteItem` property determines whether the message will be deleted.
+       */
       const event = asyncResult.asyncContext;
       event.completed({
         onErrorDeleteItem: true,
@@ -36,7 +52,3 @@ function onSpamReport(event) {
     }
   );
 }
-
-// IMPORTANT: To ensure your add-in is supported in the Outlook client on Windows, remember to map the event handler name specified in the manifest to its JavaScript counterpart
-if (Office.context.platform === Office.PlatformType.PC || Office.context.platform == null) {
-  Office.actions.associate("onSpamReport", onSpamReport); }


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes |
| New feature?    | no |
| New sample?     | no |
| Related issues? | N/A |

## What's in this Pull Request?

Moves the `Office.actions.associate` code to the `Office.onReady` call.