### PR TITLE
Update to @azure/msal-browser 3.14.0 for better logging

### DIFF
--- a/Samples/auth/Outlook-Add-in-SSO-NAA/package-lock.json
+++ b/Samples/auth/Outlook-Add-in-SSO-NAA/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-browser": "^3.11.0",
+        "@azure/msal-browser": "^3.14.0",
         "core-js": "^3.9.1",
         "regenerator-runtime": "^0.13.7"
       },
@@ -509,12 +509,20 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.11.0.tgz",
-      "integrity": "sha512-Xc0g1gdB2gdscPeuUGKmlGMgP1L/AWDeuxaToWkeautPdZqKvzeE82ggqLMctKZ0yq6e7F1XfGhUDCcUo7Db9w==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.14.0.tgz",
+      "integrity": "sha512-Un85LhOoecJ3HDTS3Uv3UWnXC9/43ZSO+Kc+anSqpZvcEt58SiO/3DuVCAe1A3I5UIBYJNMgTmZPGXQ0MVYrwA==",
       "dependencies": {
-        "@azure/msal-common": "14.8.0"
+        "@azure/msal-common": "14.10.0"
       },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
+      "version": "14.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.10.0.tgz",
+      "integrity": "sha512-Zk6DPDz7e1wPgLoLgAp0349Yay9RvcjPM5We/ehuenDNsz/t9QEFI7tRoHpp/e47I4p20XE3FiDlhKwAo3utDA==",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -523,6 +531,8 @@
       "version": "14.8.0",
       "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.8.0.tgz",
       "integrity": "sha512-FIghuAzpgmc5ZAW2rCTAHKdhGcCRqg/UyroidTgGgSRrG1gOsEbUTW+7lmEFTz84ttCv5RnjOAUUi/SQjUTw0w==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }

--- a/Samples/auth/Outlook-Add-in-SSO-NAA/package.json
+++ b/Samples/auth/Outlook-Add-in-SSO-NAA/package.json
@@ -28,7 +28,7 @@
     "watch": "webpack --mode development --watch"
   },
   "dependencies": {
-    "@azure/msal-browser": "^3.11.0",
+    "@azure/msal-browser": "^3.14.0",
     "core-js": "^3.9.1",
     "regenerator-runtime": "^0.13.7"
   },


### PR DESCRIPTION
@azure/msal-browser adds better logging around of Nested App Auth is available or not in the client, bump the package version which will be useful for diagnostic and bug reports.