### PR TITLE
Contextual tabs are only supported on Excel

### DIFF
--- a/Samples/office-contextual-tabs/README.md
+++ b/Samples/office-contextual-tabs/README.md
@@ -3,7 +3,6 @@ page_type: sample
 urlFragment: office-add-in-contextual-tabs
 products:
 - office-excel
-- office-powerpoint
 - office-365
 languages:
 - javascript
@@ -28,8 +27,8 @@ This sample accomplishes the following tasks using Office ribbon APIs.
 ## Applies to
 
 - Excel on Windows
+- Excel on Mac
 - Excel on the web
-- PowerPoint on Windows
 
 ## Prerequisites
 


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                               |
| New feature?    | no                               |
| New sample?     | no                              |
| Related issues? |  |

## What's in this Pull Request?

@akrantz reported that contextual tabs are only supported in Excel. This matches the existing [requirement set documentation](https://learn.microsoft.com/en-us/javascript/api/requirement-sets/common/ribbon-api-requirement-sets).