### PR TITLE
[Outlook] (new Outlook on Windows) Remove preview string

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ All of the following samples show how to access and work with a user's Microsoft
 | [Set your signature using Outlook event-based activation](Samples/outlook-set-signature) | Uses event-based activation to run an Outlook add-in when the user creates a new message or appointment.|
 | [Verify the color categories of a message or appointment before it's sent using Smart Alerts](Samples/outlook-check-item-categories/) | Uses Outlook Smart Alerts to verify that required color categories are applied to a new message or appointment before it's sent.|
 | [Verify the sensitivity label of a message](Samples/outlook-verify-sensitivity-label/) | Uses the sensitivity label API in an event-based add-in to verify and apply the **Highly Confidential** sensitivity label to applicable outgoing messages. |
-| [Report spam or phishing emails in Outlook (preview)](Samples/outlook-spam-reporting/) | Builds an integrated spam-reporting add-in that's displayed in a prominent spot on the Outlook ribbon. |
+| [Report spam or phishing emails in Outlook](Samples/outlook-spam-reporting/) | Builds an integrated spam-reporting add-in that's displayed in a prominent spot on the Outlook ribbon. |
 
 ## Excel
 

--- a/Samples/auth/Outlook-Add-in-SSO-events/README.md
+++ b/Samples/auth/Outlook-Add-in-SSO-events/README.md
@@ -28,7 +28,7 @@ The sample shows how to use SSO to access a user's Microsoft Graph data from an 
 
 ## Applies to
 
-- Outlook on Windows
+- Outlook on Windows ([new](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627) and classic)
 - Outlook on the web
 - [new Outlook on Mac](https://support.microsoft.com/office/6283be54-e74d-434e-babb-b70cefc77439)
 

--- a/Samples/auth/Outlook-Add-in-SSO-events/manifest.xml
+++ b/Samples/auth/Outlook-Add-in-SSO-events/manifest.xml
@@ -49,9 +49,9 @@
           <!-- Specifies the event-based activation runtime. -->
           <!-- For more information, see https://learn.microsoft.com/office/dev/add-ins/outlook/autolaunch. -->
           <Runtimes>
-            <!-- HTML file that references the JavaScript event handlers. This is used by Outlook on the web. -->
+            <!-- HTML file that references the JavaScript event handlers. This is used by Outlook on the web and on Mac, and in new Outlook on Windows. -->
             <Runtime resid="WebViewRuntime.Url">
-              <!-- JavaScript file that contains the event handlers. This is used by Outlook on Windows. -->
+              <!-- JavaScript file that contains the event handlers. This is used by classic Outlook on Windows. -->
               <Override type="javascript" resid="JSRuntime.Url"/>
             </Runtime>
           </Runtimes>

--- a/Samples/auth/Outlook-Add-in-SSO/README.md
+++ b/Samples/auth/Outlook-Add-in-SSO/README.md
@@ -16,7 +16,7 @@ description: "An Outlook add-in sample that accesses Microsoft Graph using singl
 
 # Single Sign-on (SSO) sample Outlook add-in
 
-**Applies to:** Outlook on Windows | Outlook on Mac | Outlook on the web
+**Applies to:** Outlook on Windows ([new](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627) and classic) | Outlook on Mac | Outlook on the web
 
 ## Summary
 
@@ -104,7 +104,7 @@ The browser will attempt to redirect back to your app, which may not be running.
 | `Use multi-factor auth` | `True` |
 
 1. Press **F5** to build and debug the project. You may be prompted to trust the developer certificate.
-1. You should be prompted for a user account and password. Provide a user in your Office tenant, or an Outlook.com account. The add-in will be installed for that user, and either Outlook on the web or Outlook on Windows will open.
+1. You should be prompted for a user account and password. Provide a user in your Office tenant, or an Outlook.com account. The add-in will be installed for that user, and either Outlook on the web or Outlook on Windows (new or classic) will open.
 
 1. Select any message, **that has one or more attachments**.
 1. Open the task pane:
@@ -113,7 +113,7 @@ The browser will attempt to redirect back to your app, which may not be running.
 
     ![Screen shot of the elipses button in Outlook on the web](buttons-outlook-web.PNG)
 
-    - If you're in Outlook on Windows or Mac: On the **Home** tab, select **Choose attachments**. Note that if the Outlook app window is too small, that **Choose attachments** will instead be located on the **Home** tab's **...** (**More commands**) button.
+    - If you're in Outlook on Windows (classic) or Mac: On the **Home** tab, select **Choose attachments**. Note that if the Outlook app window is too small, that **Choose attachments** will instead be located on the **Home** tab's **...** (**More commands**) button.
 
     ![Screen shot of the Choose attachments button on Home tab in Outlook on the web](buttons-outlook-desktop.png)
 
@@ -138,7 +138,7 @@ It's recommended to test all paths when working with SSO. In some scenarios, you
     let authSSO = false;
     ```
 
-There is also a `MockError` method available in the **Saveattachments.cs** controller to throw various MSAL or Microsoft Graph errors for testing.    
+There is also a `MockError` method available in the **Saveattachments.cs** controller to throw various MSAL or Microsoft Graph errors for testing.
 
 ## Troubleshoot manifest issues
 

--- a/Samples/hello-world/outlook-hello-world/README.md
+++ b/Samples/hello-world/outlook-hello-world/README.md
@@ -29,7 +29,7 @@ Learn how to build the simplest Office Add-in with only a manifest, HTML web pag
 
 ## Applies to
 
-- Outlook on Windows, Mac, and in a browser.
+- Outlook on Windows ([new](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627) and classic), Mac, and in a browser.
 
 ## Prerequisites
 
@@ -102,7 +102,7 @@ An Office Add-in requires you to configure a web server to provide all the resou
 The hello world sample is configured so that the files are hosted directly from this GitHub repo.
 
 1. Download the **manifest.xml** file from this sample to a folder on your computer.
-1. Sideload the manifest in Outlook on Windows, on Mac, or on the web by following the instructions in [Sideload Outlook add-in on Windows or Mac](https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing#outlook-on-the-desktop).
+1. Sideload the manifest in Outlook on Windows (new or classic), on Mac, or on the web by following the instructions in [Sideload Outlook add-in on Windows or Mac](https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing).
 
 ### Configure a localhost web server and run the sample from localhost
 
@@ -141,7 +141,7 @@ If you prefer to configure a web server and host the add-in's web files from you
 
    The http-server will run and host the current folder's files on `localhost:3000`.
 
-1. Now that your localhost web server is running, you can sideload the **manifest-localhost.xml** file provided in the **outlook-hello-world** folder. Using the **manifest-localhost.xml** file, follow the steps in [Sideload Outlook add-in on Windows or Mac](https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing#outlook-on-the-desktop) to sideload and run the add-in.
+1. Now that your localhost web server is running, you can sideload the **manifest-localhost.xml** file provided in the **outlook-hello-world** folder. Using the **manifest-localhost.xml** file, follow the steps in [Sideload Outlook add-in on Windows or Mac](https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing) to sideload and run the add-in.
 
 ## Test the sample on Outlook
 

--- a/Samples/outlook-check-item-categories/README.md
+++ b/Samples/outlook-check-item-categories/README.md
@@ -17,7 +17,7 @@ description: "Use Outlook Smart Alerts to verify that required color categories 
 
 # Verify the color categories of a message or appointment before it's sent using Smart Alerts
 
-**Applies to**: Outlook on Windows | [new Outlook on Mac](https://support.microsoft.com/office/6283be54-e74d-434e-babb-b70cefc77439)
+**Applies to**: classic Outlook on Windows | [new Outlook on Mac](https://support.microsoft.com/office/6283be54-e74d-434e-babb-b70cefc77439)
 
 ## Summary
 
@@ -47,9 +47,9 @@ For documentation related to this sample, see the following articles.
 - Outlook on Windows starting in Version 2206 (Build 15330.20196)
 - [New Outlook on Mac](https://support.microsoft.com/office/6283be54-e74d-434e-babb-b70cefc77439) starting in Version 16.65.827.0
 
-> **Note**: Although the Smart Alerts feature is supported in Outlook on the web, Windows, and new Mac UI (see the "Supported clients and platforms" section of [Use Smart Alerts and the onMessageSend and OnAppointmentSend events in your Outlook add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/onmessagesend-onappointmentsend-events#supported-clients-and-platforms)), this sample only runs in Outlook on Windows and Mac.
+> **Note**: Although the Smart Alerts feature is supported in Outlook on the web, Windows ([new](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627) and classic), and new Mac UI (see the "Supported clients and platforms" section of [Use Smart Alerts and the onMessageSend and OnAppointmentSend events in your Outlook add-in](https://learn.microsoft.com/office/dev/add-ins/outlook/onmessagesend-onappointmentsend-events#supported-clients-and-platforms)), this sample only runs in classic Outlook on Windows and Mac.
 >
-> As the Office.Categories API can't be used in Compose mode in Outlook on the web, this sample isn't supported on that client. To learn how to develop a Smart Alerts add-in for Outlook on the web, see the [Smart Alerts walkthrough](https://learn.microsoft.com/office/dev/add-ins/outlook/smart-alerts-onmessagesend-walkthrough).
+> As the Office.Categories API can't be used in Compose mode in Outlook on the web and new Outlook on Windows, this sample isn't supported on these client. To learn how to develop a Smart Alerts add-in for Outlook on the web and new Outlook on Windows, see the [Smart Alerts walkthrough](https://learn.microsoft.com/office/dev/add-ins/outlook/smart-alerts-onmessagesend-walkthrough).
 
 ## Prerequisites
 

--- a/Samples/outlook-check-item-categories/manifest-localhost.xml
+++ b/Samples/outlook-check-item-categories/manifest-localhost.xml
@@ -46,9 +46,9 @@
           <!-- Specifies the event-based activation runtime. -->
           <!-- For more information, see https://learn.microsoft.com/office/dev/add-ins/outlook/autolaunch. -->
           <Runtimes>
-            <!-- HTML file that references the JavaScript event handlers. This is used by Outlook on the web. -->
+            <!-- HTML file that references the JavaScript event handlers. This is used by Outlook on the web and on Mac, and in new Outlook on Windows. -->
             <Runtime resid="WebViewRuntime.Url">
-              <!-- JavaScript file that contains the event handlers. This is used by Outlook on Windows. -->
+              <!-- JavaScript file that contains the event handlers. This is used by classic Outlook on Windows. -->
               <Override type="javascript" resid="JSRuntime.Url"/>
             </Runtime>
           </Runtimes>

--- a/Samples/outlook-check-item-categories/manifest.xml
+++ b/Samples/outlook-check-item-categories/manifest.xml
@@ -46,9 +46,9 @@
           <!-- Specifies the event-based activation runtime. -->
           <!-- For more information, see https://learn.microsoft.com/office/dev/add-ins/outlook/autolaunch. -->
           <Runtimes>
-            <!-- HTML file that references the JavaScript event handlers. This is used by Outlook on the web. -->
+            <!-- HTML file that references the JavaScript event handlers. This is used by Outlook on the web and on Mac, and in new Outlook on Windows. -->
             <Runtime resid="WebViewRuntime.Url">
-              <!-- JavaScript file that contains the event handlers. This is used by Outlook on Windows. -->
+              <!-- JavaScript file that contains the event handlers. This is used by classic Outlook on Windows. -->
               <Override type="javascript" resid="JSRuntime.Url"/>
             </Runtime>
           </Runtimes>

--- a/Samples/outlook-encrypt-attachments/README.md
+++ b/Samples/outlook-encrypt-attachments/README.md
@@ -28,7 +28,7 @@ description: "Use Outlook event-based activation to encrypt attachments, process
 This sample showcases how to use event-based activation in an Outlook add-in when the user composes an email or appointment/meeting request.  It demonstrates how to run tasks based on events that fire when certain data changes when the user:
 
 - adds an attachment to an email or appointment/meeting request
-- adds recipients or distributions lists as required or optional attendees in a meeting request
+- Adds recipients or distributions lists as required or optional attendees in a meeting request.
 - changes the start or end date or time in an appointment/meeting request
 - adds a notification message to the item when a new email or appointment/meeting request is created, instructing the user to open the task pane for further information.
 

--- a/Samples/outlook-encrypt-attachments/README.md
+++ b/Samples/outlook-encrypt-attachments/README.md
@@ -17,7 +17,7 @@ description: "Use Outlook event-based activation to encrypt attachments, process
 
 # Encrypt attachments, process meeting request attendees, and react to appointment date/time changes using Outlook event-based activation
 
-**Applies to**: Outlook on Windows | Outlook on the web
+**Applies to**: Outlook on Windows ([new](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627) and classic) | Outlook on the web
 
 ![Message in compose mode with an attachment that has additional encrypted and decrypted versions created by the sample add-in.](./assets/readme/outlook-encrypt-attachments-overview.png)
 
@@ -28,7 +28,7 @@ description: "Use Outlook event-based activation to encrypt attachments, process
 This sample showcases how to use event-based activation in an Outlook add-in when the user composes an email or appointment/meeting request.  It demonstrates how to run tasks based on events that fire when certain data changes when the user:
 
 - adds an attachment to an email or appointment/meeting request
-- adds recipients or distributions lists as required or optional attendeees in a meeting request
+- adds recipients or distributions lists as required or optional attendees in a meeting request
 - changes the start or end date or time in an appointment/meeting request
 - adds a notification message to the item when a new email or appointment/meeting request is created, instructing the user to open the task pane for further information.
 
@@ -52,7 +52,7 @@ This sample showcases how to use event-based activation in an Outlook add-in whe
 ---
 
 - Outlook
-  - Windows
+  - Windows (new and classic)
   - web browser
 
 ## Prerequisites
@@ -86,7 +86,7 @@ This sample showcases how to use event-based activation in an Outlook add-in whe
 Run this sample in Outlook on Windows or in a browser. The add-in web files are served from this repo on GitHub.
 
 1. Download the **manifest.xml** file from this sample to a folder on your computer.
-1. Sideload the add-in manifest in Outlook on the web or on Windows by following the manual instructions in the article [Sideload Outlook add-ins for testing](https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing).
+1. Sideload the add-in manifest in Outlook on the web or on Windows (new or classic) by following the manual instructions in the article [Sideload Outlook add-ins for testing](https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing).
 
 ### Try it out
 
@@ -101,7 +101,7 @@ Once the add-in is loaded, use the following steps to try out the functionality.
 
 #### Set up meetings
 
-1. Create a new meeting request. In Outlook on the web, choose **More options** to expand the request and include all details. Otherwise, you won't see the notifications in the next steps.
+1. Create a new meeting request. In Outlook on the web and new Outlook on Windows, choose **More options** to expand the request and include all details. Otherwise, you won't see the notifications in the next steps.
 1. Add a user as a required or optional attendee.
     > A notification appears at the top of the message that reads **Your appointment has 1 required and 0 optional attendees**. | Dismiss
 1. Add a distribution list as a required or optional attendee.
@@ -139,14 +139,14 @@ If you prefer to host the web server for the sample on your computer, follow the
     office-addin-https-reverse-proxy --url http://localhost:3000 
     ```
 
-1. Sideload `manifest.xml` in Outlook on the web or on Windows by following the manual instructions in the article [Sideload Outlook add-ins for testing](https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing).
+1. Sideload `manifest.xml` in Outlook on the web or on Windows (new or classic) by following the manual instructions in the article [Sideload Outlook add-ins for testing](https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing).
 1. [Try out the sample!](#try-it-out)
 
 ## Key parts of this sample
 
 ### Configure event-based activation in the manifest
 
-The manifest configures a runtime that loads a single JavaScript file to handle event-based activation. The following `<Runtime>` element specifies a `commands.html` page resource id that loads the `commands.js` file on Outlook on the web. The `<Override>` element directly specifies the `commands.js` JavaScript file to load when running on Outlook on Windows. Outlook on Windows doesn't use the HTML page to load the JavaScript file.
+The manifest configures a runtime that loads a single JavaScript file to handle event-based activation. The following `<Runtime>` element specifies a `commands.html` page resource ID that loads the `commands.js` file in Outlook on the web and new Outlook on Windows. The `<Override>` element directly specifies the `commands.js` JavaScript file to load when running on classic Outlook on Windows. Classic Outlook on Windows doesn't use the HTML page to load the JavaScript file.
 
 ```xml
 <Runtime resid="WebViewRuntime.Url">
@@ -185,7 +185,7 @@ When the user creates a new message or appointment, Outlook loads the `commands.
 > [!NOTE]
 > The onItemAttachmentsChangedHandler function handles both OnMessageAttachmentsChanged and OnAppointmentAttachmentsChanged.
 
-Outlook on the web loads the `commands.html` page, which then also loads `commands.js`.
+Outlook on the web and new Outlook on Windows load the `commands.html` page, which then also loads `commands.js`.
 
 ### Task pane code
 
@@ -196,10 +196,10 @@ The task pane code is located under the `taskpane` folder of this project. The t
 
 ## Known Issues
 
-- At present, imports are not supported in the JavaScript file where you implement the handling for event-based activation. This means that external libraries (like the `crypto-js` library used in this sample) cannot be required directly in the `commands.js` file and must be loaded in `commands.html`. Since Outlook on Windows only loads `commands.js`, the `crypto-js` library cannot be loaded to perform the encryption of attachments. Only Outlook on the web can load supporting .html files with external library references. Therefore encryption is only implemented for that scenario.
-- `console.dir()` methods cannot be used in event-based activation code on Outlook on Windows.
-- `window.localStorage` cannot be used in event-based activation code on Outlook on Windows.
-- Choosing the **Open task pane** link in the InfoBar may not work in Outlook on the web. A fix has been deployed. For more information, see [Can't open task pane from link in Outlook NotificationMessages](https://github.com/OfficeDev/office-js/issues/2125) issue on GitHub.
+- At present, imports are not supported in the JavaScript file where you implement the handling for event-based activation. This means that external libraries (like the `crypto-js` library used in this sample) can't be required directly in the `commands.js` file and must be loaded in `commands.html`. Since classic Outlook on Windows only loads `commands.js`, the `crypto-js` library can't be loaded to perform the encryption of attachments. Only Outlook on the web and new Outlook on Windows can load supporting `.html` files with external library references. Therefore encryption is only implemented for that scenario.
+- `console.dir()` methods can't be used in event-based activation code in classic Outlook on Windows.
+- `window.localStorage` can't be used in event-based activation code in classic Outlook on Windows.
+- Choosing the **Open task pane** link in the InfoBar may not work in Outlook on the web and new Outlook on Windows. A fix has been deployed. For more information, see [Can't open task pane from link in Outlook NotificationMessages](https://github.com/OfficeDev/office-js/issues/2125) issue on GitHub.
 
 ## References
 

--- a/Samples/outlook-encrypt-attachments/README.md
+++ b/Samples/outlook-encrypt-attachments/README.md
@@ -27,21 +27,22 @@ description: "Use Outlook event-based activation to encrypt attachments, process
 
 This sample showcases how to use event-based activation in an Outlook add-in when the user composes an email or appointment/meeting request.  It demonstrates how to run tasks based on events that fire when certain data changes when the user:
 
-- adds an attachment to an email or appointment/meeting request
+- Adds an attachment to an email or appointment/meeting request.
 - Adds recipients or distributions lists as required or optional attendees in a meeting request.
-- changes the start or end date or time in an appointment/meeting request
-- adds a notification message to the item when a new email or appointment/meeting request is created, instructing the user to open the task pane for further information.
+- Changes the start date, end date, or time in an appointment/meeting request.
+- Adds a notification message to the item when a new email or appointment/meeting request is created, instructing the user to open the task pane for further information.
 
 ## Features/Scenario
 
 - **Encryption based on attachment change events.** This sample encrypts the first attachment that is added to a composed email or appointment, and adds it as another attachment with an "encrypted_" prefix on the file name. It then decrypts that attachment and adds it as another attachment with a "decrypted_" prefix on the file name.
-  - Also adds a notification message to the compose item to denote that encryption and decryption is in progress. When completed, that message is removed (it may only appear for a very brief time, depending on the complexity of the encryption process) and another notification message is added noting that the process has completed.
+
+  It also adds a notification message to the compose item to denote that encryption and decryption is in progress. When completed, that message is removed (it may only appear for a very brief time, depending on the complexity of the encryption process) and another notification message is added noting that the process has completed.
 
     ![Message in compose mode with the sample add-in notification message and task pane displayed.](assets/readme/compose_email.png)
 
 - **Notifications based on recipient changes.** This sample adds notification messages to a meeting request when recipients are added or removed. The notification message are removed when there are no longer any recipients.
   - Shows a message with a running tally of the number of required and optional attendees.
-  - Show a message with a warning if one or more distribution lists are invited as an attendee
+  - Show a message with a warning if one or more distribution lists are invited as an attendee.
 
 - **Notifications based on date/time changes.** This sample adds a notification message to an appointment when the user changes the date/time, showing the original date/time that was set when the appointment was opened. The notification message provides a reference for further date/time edits.
 

--- a/Samples/outlook-encrypt-attachments/manifest-localhost.xml
+++ b/Samples/outlook-encrypt-attachments/manifest-localhost.xml
@@ -51,9 +51,9 @@
           <!-- Specify the runtime for event-based activation. -->
           <!-- For more information, see https://learn.microsoft.com/office/dev/add-ins/outlook/autolaunch -->
           <Runtimes>
-            <!-- HTML file including reference to or inline JavaScript event handlers. This is used by Outlook on the web. -->
+            <!-- HTML file including reference to or inline JavaScript event handlers. This is used by Outlook on the web and on Mac, and in new Outlook on Windows. -->
             <Runtime resid="WebViewRuntime.Url"> <!-- /src/commands/commands.html -->
-              <!-- JavaScript file containing event handlers. This is used by Outlook on Windows. -->
+              <!-- JavaScript file containing event handlers. This is used by classic Outlook on Windows. -->
               <Override type="javascript" resid="JSRuntime.Url"/> 
               <!-- /src/commands/commands.js -->
             </Runtime>

--- a/Samples/outlook-encrypt-attachments/manifest.xml
+++ b/Samples/outlook-encrypt-attachments/manifest.xml
@@ -51,9 +51,9 @@
           <!-- Specify the runtime for event-based activation. -->
           <!-- For more information, see https://learn.microsoft.com/office/dev/add-ins/outlook/autolaunch -->
           <Runtimes>
-            <!-- HTML file including reference to or inline JavaScript event handlers. This is used by Outlook on the web. -->
+            <!-- HTML file including reference to or inline JavaScript event handlers. This is used by Outlook on the web and on Mac, and in new Outlook on Windows. -->
             <Runtime resid="WebViewRuntime.Url"> <!-- /src/commands/commands.html -->
-              <!-- JavaScript file containing event handlers. This is used by Outlook on Windows. -->
+              <!-- JavaScript file containing event handlers. This is used by classic Outlook on Windows. -->
               <Override type="javascript" resid="JSRuntime.Url"/> 
               <!-- /src/commands/commands.js -->
             </Runtime>

--- a/Samples/outlook-set-signature/README.md
+++ b/Samples/outlook-set-signature/README.md
@@ -18,7 +18,7 @@ description: "Use Outlook event-based activation to set the signature."
 
 # Set your signature using Outlook event-based activation
 
-**Applies to:** Outlook on Windows | Outlook on the web | Outlook on Mac (new UI)
+**Applies to:** Outlook on Windows ([new](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627) and classic) | Outlook on the web | Outlook on Mac (new UI)
 
 ## Summary
 
@@ -36,7 +36,7 @@ For documentation related to this sample, see [Configure your Outlook add-in for
 ## Applies to
 
 - Outlook
-  - Windows
+  - Windows (new and classic)
   - Web browser
   - new Mac UI
 
@@ -78,7 +78,7 @@ There are multiple ways to run this sample.
 The quickest way to run the sample is to use GitHub as the web host. However you can't debug or change the source code. The add-in web files are served from this repo on GitHub.
 
 1. Download the **manifest.xml** file from this sample to a folder on your computer.
-1. Sideload the add-in manifest in Outlook on the web, on Windows, or on Mac by following the instructions in the article [Sideload Outlook add-ins for testing](https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing).
+1. Sideload the add-in manifest in Outlook on the web, on Windows (new or classic), or on Mac by following the instructions in the article [Sideload Outlook add-ins for testing](https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing).
 
 ### Run the sample on localhost with the unified Microsoft 365 manifest
 
@@ -120,7 +120,7 @@ To debug task pane code, see [Debug add-ins on Windows using Visual Studio Code 
 
 Once the add-in is loaded use the following steps to try out the functionality.
 
-1. Open Outlook on Windows, on Mac, or in a browser.
+1. Open Outlook on Windows (new or classic), on Mac, or in a browser.
 1. Create a new message or appointment.
 
     > You should see a notification at the top of the message that reads: **Please set your signature with the Office Add-ins sample.**
@@ -155,7 +155,7 @@ The manifest configures a runtime that is loaded specifically to handle event-ba
 
 ### Configure event-based activation in the manifest.xml file
 
-The following `<Runtime>` element specifies an HTML page resource ID that loads the runtime on Outlook on the web and on Mac. The `<Override>` element specifies the JavaScript file instead, to load the runtime for Outlook on Windows. Outlook on Windows doesn't use the HTML page to load the runtime.
+The following `<Runtime>` element specifies an HTML page resource ID that loads the runtime on Outlook on the web, on Mac, and in new Outlook on Windows. The `<Override>` element specifies the JavaScript file instead, to load the runtime for Outlook on Windows. Outlook on Windows doesn't use the HTML page to load the runtime.
 
 ```xml
 <Runtime resid="Autorun">
@@ -178,7 +178,7 @@ The add-in handles two events that are mapped to the `checkSignature()` function
 
 ### Configure event-based activation in the unified manifest file
 
-If you use the unified manifest, the `manifest.json` file specifies an HTML page resource ID that loads the runtime on Outlook on the web and on Mac. The `runtimes` array includes a runtime entry that describes the event-based activation required. The `code` object identities the HTML file to load. It also identifies a Javascript file to load when using Outlook on Windows.
+If you use the unified manifest, the `manifest.json` file specifies an HTML page resource ID that loads the runtime on Outlook on the web, on Mac, and in new Outlook on Windows. The `runtimes` array includes a runtime entry that describes the event-based activation required. The `code` object identities the HTML file to load. It also identifies a Javascript file to load when using Outlook on Windows.
 
 ```json
  "runtimes": [
@@ -241,15 +241,15 @@ The add-in handles two events that are mapped to the `checkSignature()` function
 
 ### Handling the events and using the setSignatureAsync API
 
-When the user creates a new message or appointment, Outlook will load the files specified in the manifest to handle the `OnNewMessageCompose` and `OnNewAppointmentOrganizer` events. Outlook on the web and on Mac will load the `autorunweb.html` page, which then also loads `autorunweb.js` and `autorunshared.js`.
+When the user creates a new message or appointment, Outlook will load the files specified in the manifest to handle the `OnNewMessageCompose` and `OnNewAppointmentOrganizer` events. Outlook on the web, on Mac, and new Outlook on Windows will load the `autorunweb.html` page, which then also loads `autorunweb.js` and `autorunshared.js`.
 
-The `autorunweb.js` file contains a version of the `insert_auto_signature` function used specifically when running on Outlook on the web. The [setSignatureAsync() API cannot be used in Outlook on the web for appointments](https://learn.microsoft.com/javascript/api/outlook/office.body#outlook-office-body-setsignatureasync-member(1)). Therefore, `insert_auto_signature` inserts the signature into a new appointment by directly writing to the body text of the appointment.
+The `autorunweb.js` file contains a version of the `insert_auto_signature` function used specifically when running on Outlook on the web or new Outlook on Windows. The [setSignatureAsync() API can't be used in Outlook on the web or new Outlook on Windows for appointments](https://learn.microsoft.com/javascript/api/outlook/office.body#outlook-office-body-setsignatureasync-member(1)). Therefore, `insert_auto_signature` inserts the signature into a new appointment by directly writing to the body text of the appointment.
 
-The `autorunshared.js` file contains the `checkSignature` function that handles the events from Outlook. It also contains additional code that is shared and loaded when the add-in is used in Outlook on the web, on Windows, and on Mac. In Outlook on Windows, this file is loaded directly and `autorunweb.html` and `autorunweb.js` aren't loaded.
+The `autorunshared.js` file contains the `checkSignature` function that handles the events from Outlook. It also contains additional code that is shared and loaded when the add-in is used in Outlook on the web, on Windows (new and classic), and on Mac. In classic Outlook on Windows, this file is loaded directly and `autorunweb.html` and `autorunweb.js` aren't loaded.
 
 The `autorunshared.js` file contains a version of the `insert_auto_signature` function that uses the `setSignatureAsync()` API to set the signature for both messages and appointments.
 
-Note that you can use a similar pattern when handling events. If you need code that only applies to Outlook on the web, you can load it in a separate file like `autorunweb.js`. And for code that applies to Outlook on the web, on Windows, and on Mac, you can load it in a shared file like `autorunshared.js`.
+Note that you can use a similar pattern when handling events. If you need code that only applies to Outlook on the web and new Outlook on Windows, you can load it in a separate file like `autorunweb.js`. And for code that applies to Outlook on the web, on Windows (new and classic), and on Mac, you can load it in a shared file like `autorunshared.js`.
 
 ### Embedding images with the signature
 

--- a/Samples/outlook-spam-reporting/README.md
+++ b/Samples/outlook-spam-reporting/README.md
@@ -17,7 +17,7 @@ description: "Learn how to create an integrated spam-reporting add-in in Outlook
 
 # Report spam or phishing emails in Outlook
 
-**Applies to**: Outlook on the web, Outlook on Windows (classic and new)
+**Applies to**: Outlook on the web, Outlook on Windows (new and classic)
 
 ![A sample spam-reporting dialog.](./assets/readme/outlook-spam-processing-dialog.png)
 
@@ -34,7 +34,7 @@ To learn about key components of this sample, see [Implement an integrated spam-
 ## Applies to
 
 - Outlook on the web
-- [new Outlook on Windows (preview)](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627)
+- [new Outlook on Windows](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627)
 - classic Outlook on Windows starting in Version 2307 (Build 16626.10000)
 
 ## Prerequisites
@@ -46,12 +46,12 @@ A Microsoft 365 subscription.
 
 ## Run the sample
 
-Run this sample in Outlook on Windows using one of the following add-in file hosting options.
+Run this sample in Outlook on Windows (new or classic) or on the web using one of the following add-in file hosting options.
 
 ### Run the sample from GitHub
 
 1. Download the **manifest.xml** file from this sample to a folder on your computer.
-1. Sideload the add-in manifest in Outlook on Windows by following the manual instructions in [Sideload Outlook add-ins for testing](https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing#sideload-manually).
+1. Sideload the add-in manifest in Outlook on Windows (new or classic) or on the web by following the manual instructions in [Sideload Outlook add-ins for testing](https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing#sideload-manually).
 1. Follow the steps in [Try it out](#try-it-out) to test the sample.
 
 ### Run the sample from localhost
@@ -89,7 +89,7 @@ If you prefer to host the web server for the sample on your computer, follow the
 
     The http-server will run and host the current folder's files on localhost:3000.
 
-1. Now that your localhost web server is running, you can sideload the **manifest-localhost.xml** file provided in the sample folder. To sideload the manifest, follow the manual instructions in [Sideload Outlook add-ins for testing](https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing?tabs=windows-web#sideload-manually).
+1. Now that your localhost web server is running, you can sideload the **manifest-localhost.xml** file provided in the sample folder. To sideload the manifest, follow the manual instructions in [Sideload Outlook add-ins for testing](https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing#sideload-manually).
 1. Follow the steps in [Try it out](#try-it-out) to test the sample.
 
 ## Try it out

--- a/Samples/outlook-spam-reporting/assets/sample.json
+++ b/Samples/outlook-spam-reporting/assets/sample.json
@@ -3,7 +3,7 @@
       "name": "outlook-spam-reporting",
       "reponame": "office-add-in-samples",
       "source": "officedev",
-      "title": "Report spam or phishing emails in Outlook (preview)",
+      "title": "Report spam or phishing emails in Outlook",
       "shortDescription": "Build an integrated spam-reporting add-in that's displayed in a prominent spot on the Outlook ribbon.",
       "url": "https://github.com/OfficeDev/Office-Add-in-samples/tree/main/Samples/outlook-spam-reporting",
       "longDescription": [
@@ -37,7 +37,7 @@
       ],
       "references": [
         {
-          "name": "Implement an integrated spam-reporting add-in (preview)",
+          "name": "Implement an integrated spam-reporting add-in",
           "description": "Learn how to implement an integrated spam-reporting add-in in Outlook.",
           "url": "https://learn.microsoft.com/office/dev/add-ins/outlook/spam-reporting"
         }

--- a/Samples/outlook-spam-reporting/manifest-localhost.xml
+++ b/Samples/outlook-spam-reporting/manifest-localhost.xml
@@ -53,7 +53,7 @@
         <Host xsi:type="MailHost">
           <Runtimes>
             <Runtime resid="WebViewRuntime.Url">
-              <!-- References the JavaScript file that contains the spam-reporting event handler. This is used by Outlook on Windows. -->
+              <!-- References the JavaScript file that contains the spam-reporting event handler. This is used by classic Outlook on Windows. -->
               <Override type="javascript" resid="JSRuntime.Url"/>
             </Runtime>
           </Runtimes>
@@ -120,7 +120,7 @@
           <bt:String id="PreProcessingDialog.Label" DefaultValue="Report Spam Message"/>
           <bt:String id="OptionsTitle.Label" DefaultValue="Why are you reporting this email?"/>
           <bt:String id="FreeText.Label" DefaultValue="Provide additional information, if any:"/>
-          <bt:String id="MoreInfo.Label" DefaultValue="Implement an integrated spam-reporting add-in (preview)"/>
+          <bt:String id="MoreInfo.Label" DefaultValue="Implement an integrated spam-reporting add-in"/>
           <bt:String id="Option1.Label" DefaultValue="Received spam email."/>
           <bt:String id="Option2.Label" DefaultValue="Received a phishing email."/>
           <bt:String id="Option3.Label" DefaultValue="I'm not sure this is a legitimate email."/>

--- a/Samples/outlook-spam-reporting/manifest.xml
+++ b/Samples/outlook-spam-reporting/manifest.xml
@@ -53,7 +53,7 @@
         <Host xsi:type="MailHost">
           <Runtimes>
             <Runtime resid="WebViewRuntime.Url">
-              <!-- References the JavaScript file that contains the spam-reporting event handler. This is used by Outlook on Windows. -->
+              <!-- References the JavaScript file that contains the spam-reporting event handler. This is used by classic Outlook on Windows. -->
               <Override type="javascript" resid="JSRuntime.Url"/>
             </Runtime>
           </Runtimes>

--- a/Samples/outlook-tag-external/README.md
+++ b/Samples/outlook-tag-external/README.md
@@ -17,7 +17,7 @@ description: "Use Outlook event-based activation to tag external recipients."
 
 # Identify and tag external recipients using Outlook event-based activation
 
-**Applies to:** Outlook on Windows | Outlook on the web
+**Applies to:** Outlook on Windows ([new](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627) and classic) | Outlook on the web
 
 ## Summary
 
@@ -36,7 +36,7 @@ For documentation related to this sample, see [Configure your Outlook add-in for
 ## Applies to
 
 - Outlook
-  - Windows
+  - Windows (new and classic)
   - web browser
 
 ## Prerequisites
@@ -53,7 +53,7 @@ For documentation related to this sample, see [Configure your Outlook add-in for
 
 ## Version history
 
-Version  | Date | Comments
+| Version | Date | Comments |
 |---------|------|---------|
 | 1.0 | 7-6-2021 | Initial release |
 | 1.1 | 11-1-2021 | Update for GA of SessionData API and OnMessageRecipientsChanged event |
@@ -66,16 +66,16 @@ In this scenario, if the message has external recipients, the add-in prepends "[
 
 ## Run the sample
 
-You can run this sample in Outlook on Windows or in a browser. The add-in web files are served from this repo on GitHub.
+You can run this sample in Outlook on Windows (new or classic) or in a browser. The add-in web files are served from this repo on GitHub.
 
 1. Download the **manifest.xml** file from this sample to a folder on your computer.
-1. Sideload the add-in manifest in Outlook on the web or on Windows by following the manual instructions in the article [Sideload Outlook add-ins for testing](https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing).
+1. Sideload the add-in manifest in Outlook on the web or on Windows (new or classic) by following the manual instructions in the article [Sideload Outlook add-ins for testing](https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing).
 
 ### Try it out
 
 Once the add-in is loaded, use the following steps to try out the functionality.
 
-1. Open Outlook on Windows or in a browser.
+1. Open Outlook on Windows (new or classic) or in a browser.
 1. Create a new message.
 1. Add a recipient email address that's external to your organization.
 
@@ -114,12 +114,12 @@ If you prefer to host the web server for the sample on your computer, follow the
     office-addin-https-reverse-proxy --url http://localhost:3000 
     ```
 
-1. Sideload `manifest-localhost.xml` in Outlook on the web or on Windows by following the manual instructions in the article [Sideload Outlook add-ins for testing](https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing).
+1. Sideload `manifest-localhost.xml` in Outlook on the web or on Windows (new or classic) by following the manual instructions in the article [Sideload Outlook add-ins for testing](https://learn.microsoft.com/office/dev/add-ins/outlook/sideload-outlook-add-ins-for-testing).
 1. [Try out the sample!](#try-it-out)
 
 ## Configure event-based activation and AppendOnSend in the manifest
 
-The manifest configures a runtime that is loaded specifically to handle event-based activation. The following `<Runtime>` element specifies an HTML page resource ID that loads the runtime in Outlook on the web. The `<Override>` element specifies the JavaScript file to load the runtime for Outlook on Windows because Outlook on Windows doesn't use the HTML page to load the runtime.
+The manifest configures a runtime that is loaded specifically to handle event-based activation. The following `<Runtime>` element specifies an HTML page resource ID that loads the runtime in Outlook on the web and new Outlook on Windows. The `<Override>` element specifies the JavaScript file to load the runtime for classic Outlook on Windows because the client doesn't use the HTML page to load the runtime.
 
 ```xml
 <Runtime resid="WebViewRuntime.Url">
@@ -150,7 +150,7 @@ Since the add-in calls `Office.context.mailbox.item.body.appendOnSendAsync`, the
 
 ## Handle the OnMessageRecipientsChanged event, manage session data, and call the appendOnSendAsync API
 
-When the user composes a message (including replies and forwards) and changes any recipients, Outlook will load the files specified in the manifest to handle the `OnMessageRecipientsChanged` event. Outlook on the web loads the **commands.html** page, which then also loads **commands.js**. In Outlook on Windows, **commands.js** is loaded directly but **commands.html** is not loaded.
+When the user composes a message (including replies and forwards) and changes any recipients, Outlook will load the files specified in the manifest to handle the `OnMessageRecipientsChanged` event. Outlook on the web and new Outlook on Windows load the **commands.html** page, which then also loads **commands.js**. In classic Outlook on Windows, **commands.js** is loaded directly but **commands.html** is not loaded.
 
 The **commands.js** file contains the `tagExternal_onMessageRecipientsChangedHandler` function that handles the `OnMessageRecipientsChanged` event from Outlook.
 
@@ -166,11 +166,11 @@ Also, the **commands.js** file contains the following helper functions.
 
 > **Note**
 >
-> You can use a different pattern to handle events if needed. For example, if you need code that applies only to Outlook on the web but other code that applies to both Outlook on the web and on Windows, you can define separate JavaScript files. For a sample using this pattern, see [Use Outlook event-based activation to set the signature](https://github.com/OfficeDev/PnP-OfficeAddins/tree/main/Samples/outlook-set-signature).
+> You can use a different pattern to handle events if needed. For example, if you need code that applies only to Outlook on the web and new Outlook on Windows, you can define separate JavaScript files. For a sample using this pattern, see [Use Outlook event-based activation to set the signature](https://github.com/OfficeDev/PnP-OfficeAddins/tree/main/Samples/outlook-set-signature).
 
 ## Known issues
 
-- In Outlook on Windows, the `OnMessageRecipientsChanged` event fires on reply or reply all. The expected behavior is implemented in Outlook on the web where this event doesn't fire in those cases.
+- In classic Outlook on Windows, the `OnMessageRecipientsChanged` event fires on reply or reply all. The expected behavior is implemented in Outlook on the web and new Outlook on Windows where this event doesn't fire in those cases.
 
 ## Questions and feedback
 

--- a/Samples/outlook-tag-external/manifest-localhost.xml
+++ b/Samples/outlook-tag-external/manifest-localhost.xml
@@ -47,9 +47,9 @@
           <!-- For more information, see https://learn.microsoft.com/office/dev/add-ins/outlook/autolaunch -->
           <Runtimes>
             <!-- HTML file including reference to or inline JavaScript event handlers.
-                This is used by Outlook on the web. -->
+                This is used by Outlook on the web and on Mac, and in new Outlook on Windows. -->
             <Runtime resid="WebViewRuntime.Url">
-              <!-- JavaScript file containing event handlers. This is used by Outlook on Windows. -->
+              <!-- JavaScript file containing event handlers. This is used by classic Outlook on Windows. -->
               <Override type="javascript" resid="JSRuntime.Url"/>
             </Runtime>
           </Runtimes>

--- a/Samples/outlook-tag-external/manifest.xml
+++ b/Samples/outlook-tag-external/manifest.xml
@@ -47,9 +47,9 @@
           <!-- For more information, see https://learn.microsoft.com/office/dev/add-ins/outlook/autolaunch -->
           <Runtimes>
             <!-- HTML file including reference to or inline JavaScript event handlers.
-                This is used by Outlook on the web. -->
+                This is used by Outlook on the web and on Mac, and in new Outlook on Windows. -->
             <Runtime resid="WebViewRuntime.Url">
-              <!-- JavaScript file containing event handlers. This is used by Outlook on Windows. -->
+              <!-- JavaScript file containing event handlers. This is used by classic Outlook on Windows. -->
               <Override type="javascript" resid="JSRuntime.Url"/>
             </Runtime>
           </Runtimes>

--- a/Samples/outlook-verify-sensitivity-label/README.md
+++ b/Samples/outlook-verify-sensitivity-label/README.md
@@ -17,7 +17,7 @@ description: "Learn how to verify and update the sensitivity label of a message 
 
 # Verify the sensitivity label of a message
 
-**Applies to**: Outlook on Windows | Outlook on Mac | modern Outlook on the web
+**Applies to**: Outlook on Windows ([new](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627) and classic) | Outlook on Mac | modern Outlook on the web
 
 ## Summary
 
@@ -44,9 +44,10 @@ For documentation related to this sample, see the following:
 
 ## Applies to
 
-- Outlook on Windows starting in Version 2304 (Build 16327.20248)
-- Outlook on Mac starting in Version 16.77.816.0
 - Outlook on the web (modern)
+- classic Outlook on Windows starting in Version 2304 (Build 16327.20248)
+- new Outlook on Windows
+- Outlook on Mac starting in Version 16.77.816.0
 
 ## Prerequisites
 
@@ -58,7 +59,7 @@ For documentation related to this sample, see the following:
 
 ## Run the sample
 
-Run this sample in Outlook on Windows, on Mac, or on the web using one of the following add-in file hosting options.
+Run this sample in Outlook on Windows (new or classic), on Mac, or on the web using one of the following add-in file hosting options.
 
 ### Run the sample from GitHub
 
@@ -161,12 +162,12 @@ To use the sensitivity label API, the **\<Permissions\>** element of the manifes
 <Permissions>ReadWriteItem</Permissions>
 ```
 
-The manifest configures a runtime to handle event-based activation. Because the Outlook platform uses the client to determine whether to use HTML or JavaScript to load the runtime, both of these files must be referenced in the manifest. An HTML page resource ID is specified in the **\<Runtime\>** element, and a JavaScript file resource ID is specified in the **\<Override\>** element, as shown next. Outlook on Windows uses the referenced JavaScript file to load the runtime, while Outlook on Mac and on the web use the HTML file.
+The manifest configures a runtime to handle event-based activation. Because the Outlook platform uses the client to determine whether to use HTML or JavaScript to load the runtime, both of these files must be referenced in the manifest. An HTML page resource ID is specified in the **\<Runtime\>** element, and a JavaScript file resource ID is specified in the **\<Override\>** element, as shown next. Classic Outlook on Windows uses the referenced JavaScript file to load the runtime, while Outlook on the web, on Mac, and new Outlook on Windows use the HTML file.
 
 ```xml
-<!-- HTML file that references the JavaScript event handlers. This is used by Outlook on the web. -->
+<!-- HTML file that references the JavaScript event handlers. This is used by Outlook on the web and on Mac, and in new Outlook on Windows. -->
 <Runtime resid="WebViewRuntime.Url">
-    <!-- JavaScript file that contains the event handlers. This is used by Outlook on Windows. -->
+    <!-- JavaScript file that contains the event handlers. This is used by classic Outlook on Windows. -->
     <Override type="javascript" resid="JSRuntime.Url"/>
 </Runtime>
 ...
@@ -187,12 +188,12 @@ The **\<LaunchEvents\>** element maps the three events that activate the add-in 
 
 ### Configure the event handlers
 
-The event object is passed to its respective handler in the **commands.js** file for processing. To ensure that the event-based add-in runs in Outlook on Windows, the JavaScript file that contains your handlers (in this case, **commands.js**) must call `Office.actions.associate`. This method maps the function ID specified in the manifest to its respective event handler in the JavaScript file.
+The event object is passed to its respective handler in the **commands.js** file for processing. To ensure that the event-based add-in runs in classic Outlook on Windows, the JavaScript file that contains your handlers (in this case, **commands.js**) must call `Office.actions.associate`. This method maps the function ID specified in the manifest to its respective event handler in the JavaScript file.
 
 ```javascript
 /** 
  * Maps the event handler name specified in the manifest's LaunchEvent element to its JavaScript counterpart.
- * This ensures support in Outlook on Windows. 
+ * This ensures support in classic Outlook on Windows. 
  */
 if (Office.context.platform === Office.PlatformType.PC || Office.context.platform == null) {
     Office.actions.associate("onMessageRecipientsChangedHandler", onMessageRecipientsChangedHandler);

--- a/Samples/outlook-verify-sensitivity-label/manifest-localhost.xml
+++ b/Samples/outlook-verify-sensitivity-label/manifest-localhost.xml
@@ -45,9 +45,9 @@
           <!-- Specifies the event-based activation runtime. -->
           <!-- For more information, see https://learn.microsoft.com/office/dev/add-ins/outlook/autolaunch. -->
           <Runtimes>
-            <!-- HTML file that references the JavaScript event handlers. This is used by Outlook on the web. -->
+            <!-- HTML file that references the JavaScript event handlers. This is used by Outlook on the web and on Mac, and in new Outlook on Windows. -->
             <Runtime resid="WebViewRuntime.Url">
-              <!-- JavaScript file that contains the event handlers. This is used by Outlook on Windows. -->
+              <!-- JavaScript file that contains the event handlers. This is used by classic Outlook on Windows. -->
               <Override type="javascript" resid="JSRuntime.Url"/>
             </Runtime>
           </Runtimes>

--- a/Samples/outlook-verify-sensitivity-label/manifest.xml
+++ b/Samples/outlook-verify-sensitivity-label/manifest.xml
@@ -45,9 +45,9 @@
           <!-- Specifies the event-based activation runtime. -->
           <!-- For more information, see https://learn.microsoft.com/office/dev/add-ins/outlook/autolaunch. -->
           <Runtimes>
-            <!-- HTML file that references the JavaScript event handlers. This is used by Outlook on the web. -->
+            <!-- HTML file that references the JavaScript event handlers. This is used by Outlook on the web and on Mac, and in new Outlook on Windows. -->
             <Runtime resid="WebViewRuntime.Url">
-              <!-- JavaScript file that contains the event handlers. This is used by Outlook on Windows. -->
+              <!-- JavaScript file that contains the event handlers. This is used by classic Outlook on Windows. -->
               <Override type="javascript" resid="JSRuntime.Url"/>
             </Runtime>
           </Runtimes>

--- a/Samples/tutorials/outlook-tutorial/README.md
+++ b/Samples/tutorials/outlook-tutorial/README.md
@@ -28,7 +28,7 @@ This sample demonstrates the basics of working with a compose message in Outlook
 
 ## Applies to
 
-- Outlook on Windows
+- Outlook on Windows ([new](https://support.microsoft.com/office/656bb8d9-5a60-49b2-a98b-ba7822bc7627) and classic)
 - Outlook on Mac
 - Outlook on the web
 
@@ -75,7 +75,7 @@ This sample demonstrates the basics of working with a compose message in Outlook
 
 1. In the message window, choose the **Insert default gist** button in the ribbon. This opens a dialog where you add your GitHub username and select the default gist.
 
-    > In Outlook on Windows, you may need to close and reopen the new message window to pick up the latest settings from the dialog.
+    > In classic Outlook on Windows, you may need to close and reopen the new message window to pick up the latest settings from the dialog.
 
 1. In the message window, choose the **Insert gist** button in ribbon. This opens a task pane where you select the GitHub gist you want to insert into the message body.
 


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                              |
| New feature?    | no                          |
| New sample?     | no                          |
| Related issues? |  None |

## What's in this Pull Request?

- Removes the preview string from new Outlook on Windows references.
- Updates support for new Outlook on Windows where applicable.

Related PRs:
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70168
- https://github.com/OfficeDev/office-js-docs-pr/pull/4693
- https://github.com/OfficeDev/office-js-docs-reference/pull/2009
- https://github.com/OfficeDev/office-js-snippets/pull/927