### PR TITLE
Bump @azure/msal-browser to 3.24.0 for NAA samples

### DIFF
--- a/Samples/auth/Office-Add-in-SSO-NAA/package-lock.json
+++ b/Samples/auth/Office-Add-in-SSO-NAA/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-browser": "^3.17.0",
+        "@azure/msal-browser": "^3.24.0",
         "core-js": "^3.37.1",
         "regenerator-runtime": "^0.14.1"
       },
@@ -511,12 +511,20 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.17.0.tgz",
-      "integrity": "sha512-csccKXmW2z7EkZ0I3yAoW/offQt+JECdTIV/KrnRoZyM7wCSsQWODpwod8ZhYy7iOyamcHApR9uCh0oD1M+0/A==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.24.0.tgz",
+      "integrity": "sha512-JGNV9hTYAa7lsum9IMIibn2kKczAojNihGo1hi7pG0kNrcKej530Fl6jxwM05A44/6I079CSn6WxYxbVhKUmWg==",
       "dependencies": {
-        "@azure/msal-common": "14.12.0"
+        "@azure/msal-common": "14.15.0"
       },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
+      "version": "14.15.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.15.0.tgz",
+      "integrity": "sha512-ImAQHxmpMneJ/4S8BRFhjt1MZ3bppmpRPYYNyzeQPeFN288YKbb8TmmISQEbtfkQ1BPASvYZU5doIZOPBAqENQ==",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -525,6 +533,8 @@
       "version": "14.12.0",
       "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.12.0.tgz",
       "integrity": "sha512-IDDXmzfdwmDkv4SSmMEyAniJf6fDu3FJ7ncOjlxkDuT85uSnLEhZi3fGZpoR7T4XZpOMx9teM9GXBgrfJgyeBw==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }

--- a/Samples/auth/Office-Add-in-SSO-NAA/package.json
+++ b/Samples/auth/Office-Add-in-SSO-NAA/package.json
@@ -28,7 +28,7 @@
     "watch": "webpack --mode development --watch"
   },
   "dependencies": {
-    "@azure/msal-browser": "^3.17.0",
+    "@azure/msal-browser": "^3.24.0",
     "core-js": "^3.37.1",
     "regenerator-runtime": "^0.14.1"
   },

--- a/Samples/auth/Outlook-Add-in-SSO-NAA-IE/package-lock.json
+++ b/Samples/auth/Outlook-Add-in-SSO-NAA-IE/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-browser": "^3.15.0",
+        "@azure/msal-browser": "^3.24.0",
         "@azure/msal-browser-v2": "npm:@azure/msal-browser@^2.39.0",
         "core-js": "^3.9.1",
         "regenerator-runtime": "^0.13.7"
@@ -522,11 +522,11 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.15.0.tgz",
-      "integrity": "sha512-jqngIR0zGLtEHCAhgXLl+VZTFcU/9DmRSjGj5RbrLnFPL/0L9Hr68k8grvLrTIq7tjhTM5Xgh6Xc0l7JlViHQQ==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.24.0.tgz",
+      "integrity": "sha512-JGNV9hTYAa7lsum9IMIibn2kKczAojNihGo1hi7pG0kNrcKej530Fl6jxwM05A44/6I079CSn6WxYxbVhKUmWg==",
       "dependencies": {
-        "@azure/msal-common": "14.10.0"
+        "@azure/msal-common": "14.15.0"
       },
       "engines": {
         "node": ">=0.8.0"
@@ -553,9 +553,9 @@
       }
     },
     "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
-      "version": "14.10.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.10.0.tgz",
-      "integrity": "sha512-Zk6DPDz7e1wPgLoLgAp0349Yay9RvcjPM5We/ehuenDNsz/t9QEFI7tRoHpp/e47I4p20XE3FiDlhKwAo3utDA==",
+      "version": "14.15.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.15.0.tgz",
+      "integrity": "sha512-ImAQHxmpMneJ/4S8BRFhjt1MZ3bppmpRPYYNyzeQPeFN288YKbb8TmmISQEbtfkQ1BPASvYZU5doIZOPBAqENQ==",
       "engines": {
         "node": ">=0.8.0"
       }

--- a/Samples/auth/Outlook-Add-in-SSO-NAA-IE/package.json
+++ b/Samples/auth/Outlook-Add-in-SSO-NAA-IE/package.json
@@ -28,7 +28,7 @@
     "watch": "webpack --mode development --watch"
   },
   "dependencies": {
-    "@azure/msal-browser": "^3.15.0",
+    "@azure/msal-browser": "^3.24.0",
     "@azure/msal-browser-v2": "npm:@azure/msal-browser@^2.39.0",
     "core-js": "^3.9.1",
     "regenerator-runtime": "^0.13.7"

--- a/Samples/auth/Outlook-Add-in-SSO-NAA/package-lock.json
+++ b/Samples/auth/Outlook-Add-in-SSO-NAA/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-browser": "^3.21.0",
+        "@azure/msal-browser": "^3.24.0",
         "core-js": "^3.38.1",
         "regenerator-runtime": "^0.14.1"
       },
@@ -511,12 +511,20 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.21.0.tgz",
-      "integrity": "sha512-BAwcFsVvOrYzKuUZHhFuvRykUmQGq6lDxst2qGnjxnpNZc3d/tnVPcmhgvUdeKl28VSE0ltgBzT3HkdpDtz9rg==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.24.0.tgz",
+      "integrity": "sha512-JGNV9hTYAa7lsum9IMIibn2kKczAojNihGo1hi7pG0kNrcKej530Fl6jxwM05A44/6I079CSn6WxYxbVhKUmWg==",
       "dependencies": {
-        "@azure/msal-common": "14.14.1"
+        "@azure/msal-common": "14.15.0"
       },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
+      "version": "14.15.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.15.0.tgz",
+      "integrity": "sha512-ImAQHxmpMneJ/4S8BRFhjt1MZ3bppmpRPYYNyzeQPeFN288YKbb8TmmISQEbtfkQ1BPASvYZU5doIZOPBAqENQ==",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -525,6 +533,8 @@
       "version": "14.14.1",
       "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.14.1.tgz",
       "integrity": "sha512-2Q3tqNz/PZLfSr8BvcHZVpRRfSn4MjGSqjj9J+HlBsmbf1Uu4P0WeXnemjTJwwx9KrmplsrN3UkZ/LPOR720rw==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }

--- a/Samples/auth/Outlook-Add-in-SSO-NAA/package.json
+++ b/Samples/auth/Outlook-Add-in-SSO-NAA/package.json
@@ -28,7 +28,7 @@
     "watch": "webpack --mode development --watch"
   },
   "dependencies": {
-    "@azure/msal-browser": "^3.21.0",
+    "@azure/msal-browser": "^3.24.0",
     "core-js": "^3.38.1",
     "regenerator-runtime": "^0.14.1"
   },

--- a/Samples/auth/Outlook-Event-SSO-NAA/package-lock.json
+++ b/Samples/auth/Outlook-Event-SSO-NAA/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-browser": "^3.15.0",
+        "@azure/msal-browser": "^3.24.0",
         "core-js": "^3.36.0",
         "regenerator-runtime": "^0.14.1"
       },
@@ -509,12 +509,20 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.20.0.tgz",
-      "integrity": "sha512-ErsxbfCGIwdqD8jipqdxpfAGiUEQS7MWUe39Rjhl0ZVPsb1JEe9bZCe2+0g23HDH6DGyCAtnTNN9scPtievrMQ==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.24.0.tgz",
+      "integrity": "sha512-JGNV9hTYAa7lsum9IMIibn2kKczAojNihGo1hi7pG0kNrcKej530Fl6jxwM05A44/6I079CSn6WxYxbVhKUmWg==",
       "dependencies": {
-        "@azure/msal-common": "14.14.0"
+        "@azure/msal-common": "14.15.0"
       },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
+      "version": "14.15.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.15.0.tgz",
+      "integrity": "sha512-ImAQHxmpMneJ/4S8BRFhjt1MZ3bppmpRPYYNyzeQPeFN288YKbb8TmmISQEbtfkQ1BPASvYZU5doIZOPBAqENQ==",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -523,6 +531,8 @@
       "version": "14.14.0",
       "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.14.0.tgz",
       "integrity": "sha512-OxcOk9H1/1fktHh6//VCORgSNJc2dCQObTm6JNmL824Z6iZSO6eFo/Bttxe0hETn9B+cr7gDouTQtsRq3YPuSQ==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }

--- a/Samples/auth/Outlook-Event-SSO-NAA/package.json
+++ b/Samples/auth/Outlook-Event-SSO-NAA/package.json
@@ -28,7 +28,7 @@
     "watch": "webpack --mode development --watch"
   },
   "dependencies": {
-    "@azure/msal-browser": "^3.15.0",
+    "@azure/msal-browser": "^3.24.0",
     "core-js": "^3.36.0",
     "regenerator-runtime": "^0.14.1"
   },


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                              |
| New feature?    | no                              |
| New sample?     | no                              |
| Related issues? |  |

## What's in this Pull Request?

Bump @azure/msal-browser to 3.24.0 for the NAA samples. Version 3.21.0 which was used for a sample has a bug that caused compatibility issues with Office, need to make sure developers aren't using this version.
