### PR TITLE
Fix wrong script path in NAA event sample

### DIFF
--- a/Samples/auth/Outlook-Event-SSO-NAA/src/well-known/microsoft-officeaddins-allowed.json
+++ b/Samples/auth/Outlook-Event-SSO-NAA/src/well-known/microsoft-officeaddins-allowed.json
@@ -1,6 +1,3 @@
 {
-    "allowed":
-    [
-        "https://localhost:3000/public/launchevent.js"
-    ]
+  "allowed": ["https://localhost:3000/launchevent.js"]
 }


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                              |
| New feature?    | no                             |
| New sample?     | no                              |
| Related issues? |  |

## What's in this Pull Request?

The path in .well-known/microsoft-officeaddins-allowed.json is incorrect and causes the NAA flow to fail. It needs to match the path loaded from the manifest.