### PR TITLE
[Outlook] Fix NAA event sample not loading on older runtime versions

### DIFF
--- a/Samples/auth/Outlook-Event-SSO-NAA/package-lock.json
+++ b/Samples/auth/Outlook-Event-SSO-NAA/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-browser": "^3.24.0",
+        "@azure/msal-browser": "^3.26.1",
         "core-js": "^3.36.0",
         "regenerator-runtime": "^0.14.1"
       },
@@ -509,9 +509,9 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.24.0.tgz",
-      "integrity": "sha512-JGNV9hTYAa7lsum9IMIibn2kKczAojNihGo1hi7pG0kNrcKej530Fl6jxwM05A44/6I079CSn6WxYxbVhKUmWg==",
+      "version": "3.26.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.26.1.tgz",
+      "integrity": "sha512-y78sr9g61aCAH9fcLO1um+oHFXc1/5Ap88RIsUSuzkm0BHzFnN+PXGaQeuM1h5Qf5dTnWNOd6JqkskkMPAhh7Q==",
       "dependencies": {
         "@azure/msal-common": "14.15.0"
       },

--- a/Samples/auth/Outlook-Event-SSO-NAA/package.json
+++ b/Samples/auth/Outlook-Event-SSO-NAA/package.json
@@ -28,7 +28,7 @@
     "watch": "webpack --mode development --watch"
   },
   "dependencies": {
-    "@azure/msal-browser": "^3.24.0",
+    "@azure/msal-browser": "^3.26.1",
     "core-js": "^3.36.0",
     "regenerator-runtime": "^0.14.1"
   },

--- a/Samples/auth/Outlook-Event-SSO-NAA/webpack.config.js
+++ b/Samples/auth/Outlook-Event-SSO-NAA/webpack.config.js
@@ -32,14 +32,22 @@ module.exports = async (env, options) => {
     module: {
       rules: [
         {
-          test: /\.js$/,
+          test: /\.m?js$/,
           // exclude: /node_modules/, // Exclude all node_modules except @azure
           include: [path.resolve(__dirname, "node_modules/@azure"), path.resolve(__dirname, "src")],
-          exclude: /node_modules/,
           use: {
             loader: "babel-loader",
             options: {
-              presets: ["@babel/preset-env"],
+              presets: [
+                [
+                  "@babel/preset-env",
+                  {
+                    targets: {
+                      browsers: ["since 2015"], // Create a bundle that is compatible with loading in older versions of Office clients.
+                    },
+                  },
+                ],
+              ],
             },
           },
         },


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                              |
| New feature?    | no                               |
| New sample?     | no                              |
| Related issues? |  |

## What's in this Pull Request?

Older versions of Outlook Win32 event-based runtime does not support ECMAScript version that @azure/msal-browser dependency uses, so it is causing issues loading the launchevent.js bundle. Configure webpack to target ES6 when producing the bundle.