### PR TITLE
Add m365 product tag to samples

### DIFF
--- a/Excel-custom-functions/AzureFunction/README.md
+++ b/Excel-custom-functions/AzureFunction/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: azure-function-with-excel-custom-function
 products:
+  - m365
   - office
   - office-excel
   - azure-functions

--- a/Excel-custom-functions/Batching/README.md
+++ b/Excel-custom-functions/Batching/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: excel-custom-function-batching-pattern
 products:
+  - m365
   - office
   - office-excel
 languages:

--- a/Excel-custom-functions/Storage/README.md
+++ b/Excel-custom-functions/Storage/README.md
@@ -1,6 +1,7 @@
 ---
 page_type: sample
 products:
+  - m365
   - office
   - office-excel
 languages:

--- a/Excel-custom-functions/web-worker/readme.md
+++ b/Excel-custom-functions/web-worker/readme.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: excel-custom-function-web-worker-pattern
 products:
+  - m365
   - office
   - office-excel
 languages:

--- a/Samples/Excel.OfflineStorageAddin/README.md
+++ b/Samples/Excel.OfflineStorageAddin/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: office-add-in-access-data-offline
 products:
+  - m365
   - office
   - office-excel
   - office-powerpoint

--- a/Samples/VSTO-shared-code-migration/README.md
+++ b/Samples/VSTO-shared-code-migration/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: office-add-in-migrate-vsto-to-web
 products:
+  - m365
   - office
   - office-excel
   - office-outlook

--- a/Samples/auth/Office-Add-in-ASPNET-SSO/README.md
+++ b/Samples/auth/Office-Add-in-ASPNET-SSO/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: office-add-in-sso-aspnet
 products:
+  - m365
   - office
   - office-excel
   - office-powerpoint

--- a/Samples/auth/Office-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-es-es.md
+++ b/Samples/auth/Office-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-es-es.md
@@ -1,6 +1,8 @@
 ---
 page_type: sample
 products:
+  - m365
+  - office
   - office-excel
 languages:
   - javascript

--- a/Samples/auth/Office-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-fr-fr.md
+++ b/Samples/auth/Office-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-fr-fr.md
@@ -1,6 +1,7 @@
 ---
 page_type: sample
 products:
+  - m365
   - office
   - office-excel
 languages:

--- a/Samples/auth/Office-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-ja-jp.md
+++ b/Samples/auth/Office-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-ja-jp.md
@@ -1,6 +1,7 @@
 ---
 page_type: sample
 products:
+  - m365
   - office
   - office-excel
 languages:

--- a/Samples/auth/Office-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-pt-br.md
+++ b/Samples/auth/Office-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-pt-br.md
@@ -1,6 +1,7 @@
 ---
 page_type: sample
 products:
+  - m365
   - office
   - office-excel
 languages:

--- a/Samples/auth/Office-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-ru-ru.md
+++ b/Samples/auth/Office-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-ru-ru.md
@@ -1,6 +1,7 @@
 ---
 page_type: sample
 products:
+  - m365
   - office
   - office-excel
 languages:

--- a/Samples/auth/Office-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-zh-cn.md
+++ b/Samples/auth/Office-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-zh-cn.md
@@ -1,6 +1,7 @@
 ---
 page_type: sample
 products:
+  - m365
   - office
   - office-excel
 languages:

--- a/Samples/auth/Office-Add-in-Microsoft-Graph-ASPNET/README.md
+++ b/Samples/auth/Office-Add-in-Microsoft-Graph-ASPNET/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: office-add-in-auth-aspnet-graph
 products:
+  - m365
   - office
   - office-excel
   - ms-graph

--- a/Samples/auth/Office-Add-in-Microsoft-Graph-React/README.md
+++ b/Samples/auth/Office-Add-in-Microsoft-Graph-React/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: office-add-in-auth-graph-react
 products:
+  - m365
   - office
   - office-excel
   - office-powerpoint

--- a/Samples/auth/Office-Add-in-NodeJS-SSO/README.md
+++ b/Samples/auth/Office-Add-in-NodeJS-SSO/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: office-add-in-sso-nodejs
 products:
+  - m365
   - office
   - office-excel
   - office-powerpoint

--- a/Samples/auth/Office-Add-in-SSO-NAA/README.md
+++ b/Samples/auth/Office-Add-in-SSO-NAA/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: office-add-in-sso-naa
 products:
+  - m365
   - office
   - office-excel
   - office-word

--- a/Samples/auth/Outlook-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-es-es.md
+++ b/Samples/auth/Outlook-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-es-es.md
@@ -1,6 +1,7 @@
 ---
 page_type: sample
 products:
+  - m365
   - office
   - office-outlook
 languages:

--- a/Samples/auth/Outlook-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-fr-fr.md
+++ b/Samples/auth/Outlook-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-fr-fr.md
@@ -1,6 +1,7 @@
 ---
 page_type: sample
 products:
+  - m365
   - office
   - office-outlook
 languages:

--- a/Samples/auth/Outlook-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-ja-jp.md
+++ b/Samples/auth/Outlook-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-ja-jp.md
@@ -1,6 +1,7 @@
 ---
 page_type: sample
 products:
+  - m365
   - office
   - office-outlook
 languages:

--- a/Samples/auth/Outlook-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-pt-br.md
+++ b/Samples/auth/Outlook-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-pt-br.md
@@ -1,6 +1,7 @@
 ---
 page_type: sample
 products:
+  - m365
   - office
   - office-outlook
 languages:

--- a/Samples/auth/Outlook-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-ru-ru.md
+++ b/Samples/auth/Outlook-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-ru-ru.md
@@ -1,6 +1,7 @@
 ---
 page_type: sample
 products:
+  - m365
   - office
   - office-outlook
 languages:

--- a/Samples/auth/Outlook-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-zh-cn.md
+++ b/Samples/auth/Outlook-Add-in-Microsoft-Graph-ASPNET/README-Localized/README-zh-cn.md
@@ -1,6 +1,7 @@
 ---
 page_type: sample
 products:
+  - m365
   - office
   - office-outlook
 languages:

--- a/Samples/auth/Outlook-Add-in-Microsoft-Graph-ASPNET/README.md
+++ b/Samples/auth/Outlook-Add-in-Microsoft-Graph-ASPNET/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: outlook-add-in-auth-aspnet-graph
 products:
+  - m365
   - office
   - office-outlook
   - ms-graph

--- a/Samples/auth/Outlook-Add-in-SSO-NAA-IE/README.md
+++ b/Samples/auth/Outlook-Add-in-SSO-NAA-IE/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: outlook-add-in-sso-naa-ie
 products:
+  - m365
   - office
   - office-outlook
 languages:

--- a/Samples/auth/Outlook-Add-in-SSO-NAA-Identity/README.md
+++ b/Samples/auth/Outlook-Add-in-SSO-NAA-Identity/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: outlook-add-in-sso-naa-identity
 products:
+  - m365
   - office
   - office-outlook
 languages:

--- a/Samples/auth/Outlook-Add-in-SSO-NAA/README.md
+++ b/Samples/auth/Outlook-Add-in-SSO-NAA/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: outlook-add-in-sso-naa
 products:
+  - m365
   - office
   - office-outlook
 languages:

--- a/Samples/auth/Outlook-Add-in-SSO-events/README.md
+++ b/Samples/auth/Outlook-Add-in-SSO-events/README.md
@@ -5,6 +5,7 @@ urlFragment: outlook-add-in-sso-event-based-activation
 products:
   - office-outlook
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/auth/Outlook-Add-in-SSO/README.md
+++ b/Samples/auth/Outlook-Add-in-SSO/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: outlook-add-in-sso-aspnet
 products:
+  - m365
   - office
   - office-outlook
 languages:

--- a/Samples/auth/Outlook-Event-SSO-NAA/README.md
+++ b/Samples/auth/Outlook-Event-SSO-NAA/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: outlook-event-sso-naa
 products:
+  - m365
   - office
   - office-outlook
 languages:

--- a/Samples/blazor-add-in/excel-blazor-add-in/README.md
+++ b/Samples/blazor-add-in/excel-blazor-add-in/README.md
@@ -4,6 +4,7 @@ urlFragment: excel-blazor-add-in
 products:
   - office-excel
   - office
+  - m365
 languages:
   - javascript
   - C#

--- a/Samples/blazor-add-in/outlook-blazor-add-in/README.md
+++ b/Samples/blazor-add-in/outlook-blazor-add-in/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: outlook-blazor-add-in
 products:
+  - m365
   - office
   - office-outlook
 languages:

--- a/Samples/blazor-add-in/word-blazor-add-in/README.md
+++ b/Samples/blazor-add-in/word-blazor-add-in/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: word-blazor-add-in
 products:
+  - m365
   - office
   - office-word
 languages:

--- a/Samples/dynamic-dpi/readme.md
+++ b/Samples/dynamic-dpi/readme.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: dynamic-dpi-code-samples
 products:
+  - m365
   - office
   - office-excel
   - office-outlook

--- a/Samples/excel-add-in-chart-analyze-data/README.md
+++ b/Samples/excel-add-in-chart-analyze-data/README.md
@@ -4,6 +4,7 @@ urlFragment: excel-add-in-chart-analyze-data
 products:
   - office-excel
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/excel-add-in-mail-merge/README.md
+++ b/Samples/excel-add-in-mail-merge/README.md
@@ -4,6 +4,7 @@ urlFragment: excel-add-in-mail-merge
 products:
   - office-excel
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/excel-add-in-shape-dashboard/README.md
+++ b/Samples/excel-add-in-shape-dashboard/README.md
@@ -4,6 +4,7 @@ urlFragment: excel-add-in-shape-dashboard
 products:
   - office-excel
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/excel-create-worksheet-from-web-site/README.md
+++ b/Samples/excel-create-worksheet-from-web-site/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: excel-add-in-create-spreadsheet-from-web-page
 products:
+  - m365
   - office
   - office-excel
 languages:

--- a/Samples/excel-data-types-explorer/README.md
+++ b/Samples/excel-data-types-explorer/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: office-excel-add-in-data-types-explorer
 products:
+  - m365
   - office
   - office-excel
 languages:

--- a/Samples/excel-get-started-with-dev-kit/README.md
+++ b/Samples/excel-get-started-with-dev-kit/README.md
@@ -4,6 +4,7 @@ urlFragment: excel-get-started-with-dev-kit
 products:
   - office-excel
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/excel-insert-file/README.md
+++ b/Samples/excel-insert-file/README.md
@@ -4,6 +4,7 @@ urlFragment: excel-add-in-insert-external-file
 products:
   - office-excel
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/excel-open-in-teams/README.md
+++ b/Samples/excel-open-in-teams/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: office-excel-add-in-open-in-teams
 products:
+  - m365
   - office
   - office-excel
   - office-teams

--- a/Samples/excel-shared-runtime-global-state/README.md
+++ b/Samples/excel-shared-runtime-global-state/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: office-add-in-shared-runtime-global-data
 products:
+  - m365
   - office
   - office-excel
 languages:

--- a/Samples/excel-shared-runtime-scenario/README.md
+++ b/Samples/excel-shared-runtime-scenario/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: office-add-in-ribbon-task-pane-ui
 products:
+  - m365
   - office
   - office-excel
 languages:

--- a/Samples/hello-world/README.md
+++ b/Samples/hello-world/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: office-add-in-hello-world
 products:
+  - m365
   - office
   - office-excel
   - office-outlook

--- a/Samples/hello-world/excel-hello-world/README.md
+++ b/Samples/hello-world/excel-hello-world/README.md
@@ -4,6 +4,7 @@ urlFragment: excel-add-in-hello-world
 products:
   - office-excel
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/hello-world/outlook-hello-world/README.md
+++ b/Samples/hello-world/outlook-hello-world/README.md
@@ -4,6 +4,7 @@ urlFragment: outlook-add-in-hello-world
 products:
   - office-outlook
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/hello-world/powerpoint-hello-world/README.md
+++ b/Samples/hello-world/powerpoint-hello-world/README.md
@@ -4,6 +4,7 @@ urlFragment: powerpoint-add-in-hello-world
 products:
   - office-powerpoint
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/hello-world/word-hello-world/README.md
+++ b/Samples/hello-world/word-hello-world/README.md
@@ -4,6 +4,7 @@ urlFragment: word-add-in-hello-world
 products:
   - office-word
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/office-add-in-commands/README.md
+++ b/Samples/office-add-in-commands/README.md
@@ -6,6 +6,7 @@ products:
   - office-word
   - office-powerpoint
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/office-add-in-commands/auto-open-task-pane/README.md
+++ b/Samples/office-add-in-commands/auto-open-task-pane/README.md
@@ -5,6 +5,7 @@ products:
   - office-add-ins
   - office-word
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/office-add-in-commands/excel/README.md
+++ b/Samples/office-add-in-commands/excel/README.md
@@ -5,6 +5,7 @@ products:
   - office-add-ins
   - office-excel
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/office-add-in-commands/powerpoint/README.md
+++ b/Samples/office-add-in-commands/powerpoint/README.md
@@ -5,6 +5,7 @@ products:
   - office-add-ins
   - office-powerpoint
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/office-add-in-commands/word/README.md
+++ b/Samples/office-add-in-commands/word/README.md
@@ -5,6 +5,7 @@ products:
   - office-add-ins
   - office-word
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/office-add-in-save-custom-settings/README.md
+++ b/Samples/office-add-in-save-custom-settings/README.md
@@ -7,6 +7,7 @@ products:
   - office-word
   - office-powerpoint
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/office-contextual-tabs/README.md
+++ b/Samples/office-contextual-tabs/README.md
@@ -4,6 +4,7 @@ urlFragment: office-add-in-contextual-tabs
 products:
   - office-excel
   - office
+  - m365
 languages:
 - javascript
 extensions:

--- a/Samples/office-keyboard-shortcuts/README.md
+++ b/Samples/office-keyboard-shortcuts/README.md
@@ -5,6 +5,7 @@ products:
   - office-excel
   - office-word
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/outlook-check-item-categories/README.md
+++ b/Samples/outlook-check-item-categories/README.md
@@ -5,6 +5,7 @@ urlFragment: outlook-add-in-check-item-categories
 products:
   - office-outlook
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/outlook-encrypt-attachments/README.md
+++ b/Samples/outlook-encrypt-attachments/README.md
@@ -5,6 +5,7 @@ urlFragment: outlook-add-in-encrypt-attachments
 products:
   - office-outlook
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/outlook-set-signature/README.md
+++ b/Samples/outlook-set-signature/README.md
@@ -6,6 +6,7 @@ products:
   - office-outlook
   - office
   - office-teams
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/outlook-spam-reporting/README.md
+++ b/Samples/outlook-spam-reporting/README.md
@@ -5,6 +5,7 @@ urlFragment: outlook-spam-reporting
 products:
   - office-outlook
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/outlook-tag-external/README.md
+++ b/Samples/outlook-tag-external/README.md
@@ -5,6 +5,7 @@ urlFragment: outlook-add-in-tag-external-recipients
 products:
   - office-outlook
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/outlook-verify-sensitivity-label/README.md
+++ b/Samples/outlook-verify-sensitivity-label/README.md
@@ -5,6 +5,7 @@ urlFragment: outlook-verify-sensitivity-label
 products:
   - office-outlook
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/tutorials/excel-tutorial/README.md
+++ b/Samples/tutorials/excel-tutorial/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: office-excel-add-in-tutorial
 products:
+  - m365
   - office
   - office-excel
 languages:

--- a/Samples/tutorials/first-run-experience-tutorial/README.md
+++ b/Samples/tutorials/first-run-experience-tutorial/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: office-add-in-first-run-experience-tutorial
 products:
+  - m365
   - office
   - office-excel
   - office-onenote

--- a/Samples/tutorials/outlook-tutorial/README.md
+++ b/Samples/tutorials/outlook-tutorial/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: office-outlook-add-in-tutorial
 products:
+  - m365
   - office
   - office-outlook
 languages:

--- a/Samples/tutorials/powerpoint-tutorial-yo/README.md
+++ b/Samples/tutorials/powerpoint-tutorial-yo/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: office-powerpoint-add-in-tutorial-yo
 products:
+  - m365
   - office
   - office-powerpoint
 languages:

--- a/Samples/tutorials/powerpoint-tutorial/README.md
+++ b/Samples/tutorials/powerpoint-tutorial/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: office-powerpoint-add-in-tutorial
 products:
+  - m365
   - office
   - office-powerpoint
 languages:

--- a/Samples/tutorials/word-tutorial/README.md
+++ b/Samples/tutorials/word-tutorial/README.md
@@ -2,6 +2,7 @@
 page_type: sample
 urlFragment: office-word-add-in-tutorial
 products:
+  - m365
   - office
   - office-word
 languages:

--- a/Samples/word-add-in-get-set-edit-openxml/README.md
+++ b/Samples/word-add-in-get-set-edit-openxml/README.md
@@ -4,6 +4,7 @@ urlFragment: word-get-set-edit-ooxml
 products:
   - office-word
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/word-add-in-load-and-write-open-xml/README.md
+++ b/Samples/word-add-in-load-and-write-open-xml/README.md
@@ -4,6 +4,7 @@ urlFragment: word-add-in-load-and-write-open-xml
 products:
   - office-word
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/word-ai-generated-content/README.md
+++ b/Samples/word-ai-generated-content/README.md
@@ -4,6 +4,7 @@ urlFragment: word-ai-generated-content
 products:
   - office-word
   - office
+  - m365
 languages:
   - typescript
 extensions:

--- a/Samples/word-citation-management/README.md
+++ b/Samples/word-citation-management/README.md
@@ -4,6 +4,7 @@ urlFragment: word-citation-management
 products:
   - office-word
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/word-get-started-with-dev-kit/README.md
+++ b/Samples/word-get-started-with-dev-kit/README.md
@@ -4,6 +4,7 @@ urlFragment: word-get-started-with-dev-kit
 products:
   - office-word
   - office
+  - m365
 languages:
   - javascript
 extensions:

--- a/Samples/word-import-template/README.md
+++ b/Samples/word-import-template/README.md
@@ -4,6 +4,7 @@ urlFragment: word-import-template
 products:
   - office-word
   - office
+  - m365
 languages:
   - javascript
 extensions:


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                               |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? | none |

## What's in this Pull Request?

Adds m365 product tag to samples so they'll show up under Microsoft 365 Product filter in Learn.