### PR TITLE
Add script to run npm audit fix command throughout repo

### DIFF
--- a/npm-audit-fix.sh
+++ b/npm-audit-fix.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Define the base directory to search
+BASE_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+echo "Base directory: $BASE_DIR"
+
+# Define the file name or pattern to search for
+FILE_PATTERN="package-lock.json"
+
+# Find files and switch to their directories
+find "$BASE_DIR" -type f -name "$FILE_PATTERN" | while read -r FILE; do
+  DIR=$(dirname "$FILE")  # Extract the directory path
+  echo "Switching to directory: $DIR"
+  cd "$DIR" || exit       # Change to the directory
+  echo "Running npm audit fix (breaking changes will need to be addressed manually)"
+  npm audit fix --package-lock-only || true
+  cd "$BASE_DIR" || exit  # Return to base directory
+done

--- a/npm-audit-fix.sh
+++ b/npm-audit-fix.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Define directory name to exclude
+EXCLUDE_DIR="node_modules"
+
 # Define the base directory to search
 BASE_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 echo "Base directory: $BASE_DIR"
@@ -10,7 +13,11 @@ FILE_PATTERN="package-lock.json"
 # Find files and switch to their directories
 find "$BASE_DIR" -type f -name "$FILE_PATTERN" | while read -r FILE; do
   DIR=$(dirname "$FILE")  # Extract the directory path
-  echo "Switching to directory: $DIR"
+  if [[ "$DIR" == *"$EXCLUDE_DIR"* ]]; then
+    echo -e "\e[33mSkipping excluded directory: $DIR\e[0m"
+    continue
+  fi
+  echo -e "\e[32mSwitching to directory: $DIR\e[0m"
   cd "$DIR" || exit       # Change to the directory
   echo "Running npm audit fix (breaking changes will need to be addressed manually)"
   npm audit fix --package-lock-only || true


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                               |
| New feature?    | no                               |
| New sample?     | no                               |
| Related issues? | none |

## What's in this Pull Request?

Adds script that runs `npm audit fix` on all package-lock files in repo. Eventually want to have GitHub Action workflow run this periodically.